### PR TITLE
Add Flask interface for lineup optimization and simulations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,56 @@
+import os
+import tempfile
+import zipfile
+from flask import Flask, render_template, request, send_file
+from src.nfl_optimizer import NFL_Optimizer
+from src.nfl_showdown_optimizer import NFL_Showdown_Optimizer
+from src.nfl_gpp_simulator import NFL_GPP_Simulator
+from src.nfl_showdown_simulator import NFL_Showdown_Simulator
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/optimize', methods=['POST'])
+def optimize():
+    site = request.form['site']
+    num_lineups = request.form['num_lineups']
+    num_uniques = request.form['num_uniques']
+    mode = request.form.get('mode', 'classic')
+
+    if mode == 'showdown':
+        opto = NFL_Showdown_Optimizer(site, num_lineups, num_uniques)
+    else:
+        opto = NFL_Optimizer(site, num_lineups, num_uniques)
+    opto.optimize()
+    output_path = opto.output()
+    return send_file(output_path, as_attachment=True)
+
+@app.route('/simulate', methods=['POST'])
+def simulate():
+    site = request.form['site']
+    field_size = request.form['field_size']
+    num_iterations = request.form['num_iterations']
+    mode = request.form.get('mode', 'classic')
+
+    if mode == 'showdown':
+        sim = NFL_Showdown_Simulator(site, field_size, num_iterations, False, False)
+        sim.generate_field_lineups()
+        sim.run_tournament_simulation()
+        lineup_path, exposure_path = sim.save_results()
+    else:
+        sim = NFL_GPP_Simulator(site, field_size, num_iterations, False, False)
+        sim.generate_field_lineups()
+        sim.run_tournament_simulation()
+        lineup_path, exposure_path = sim.output()
+
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.zip')
+    with zipfile.ZipFile(tmp.name, 'w') as zf:
+        zf.write(lineup_path, os.path.basename(lineup_path))
+        zf.write(exposure_path, os.path.basename(exposure_path))
+    return send_file(tmp.name, as_attachment=True, download_name='results.zip')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -2348,13 +2348,13 @@ class NFL_GPP_Simulator:
                     )
             unique[index] = lineup_str
 
-        out_path = os.path.join(
+        lineups_path = os.path.join(
             os.path.dirname(__file__),
             "../output/{}_gpp_sim_lineups_{}_{}.csv".format(
                 self.site, self.field_size, self.num_iterations
             ),
         )
-        with open(out_path, "w") as f:
+        with open(lineups_path, "w") as f:
             if self.site == "dk":
                 if self.use_contest_data:
                     f.write(
@@ -2377,13 +2377,13 @@ class NFL_GPP_Simulator:
             for fpts, lineup_str in unique.items():
                 f.write("%s\n" % lineup_str)
 
-        out_path = os.path.join(
+        exposure_path = os.path.join(
             os.path.dirname(__file__),
             "../output/{}_gpp_sim_player_exposure_{}_{}.csv".format(
                 self.site, self.field_size, self.num_iterations
             ),
         )
-        with open(out_path, "w") as f:
+        with open(exposure_path, "w") as f:
             f.write(
                 "Player,Position,Team,Win%,Top1%,Sim. Own%,Proj. Own%,Avg. Return\n"
             )
@@ -2433,3 +2433,5 @@ class NFL_GPP_Simulator:
                         roi_p,
                     )
                 )
+
+        return lineups_path, exposure_path

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -1,4 +1,4 @@
-import json5 as json
+import json
 import csv
 import os
 import datetime
@@ -935,6 +935,7 @@ class NFL_Optimizer:
                 f.write("%s\n" % lineup_str)
 
         print("Output done.")
+        return out_path
 
     def sort_lineup(self, lineup):
         copy_lineup = copy.deepcopy(lineup)

--- a/src/nfl_showdown_optimizer.py
+++ b/src/nfl_showdown_optimizer.py
@@ -1,4 +1,4 @@
-import json5 as json
+import json
 import csv
 import os
 import datetime
@@ -870,3 +870,4 @@ class NFL_Showdown_Optimizer:
                 f.write("%s\n" % lineup_str)
 
         print("Output done.")
+        return out_path

--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -1617,6 +1617,7 @@ class NFL_Showdown_Simulator:
                 f.write(
                     f"{p_name},{sd_position},{position},{team},{win_p}%,{top10_p}%,{field_p}%,{proj_own}%,${roi_p}\n"
                 )
+        return out_path
 
     def save_results(self):
         unique = self.output()
@@ -1624,7 +1625,7 @@ class NFL_Showdown_Simulator:
         # First output file
         # include timetsamp in filename, formatted as readable
         now = datetime.datetime.now().strftime("%a_%I_%M_%S%p").lower()
-        out_path = os.path.join(
+        lineups_path = os.path.join(
             os.path.dirname(__file__),
             "../output/{}_sd_sim_lineups_{}_{}_{}.csv".format(
                 self.site, self.field_size, self.num_iterations, now
@@ -1632,28 +1633,29 @@ class NFL_Showdown_Simulator:
         )
         if self.site == "dk":
             if self.use_contest_data:
-                with open(out_path, "w") as f:
+                with open(lineups_path, "w") as f:
                     header = "Type,CPT,FLEX,FLEX,FLEX,FLEX,FLEX,Salary,Fpts Proj,Field Fpts Proj,Ceiling,Primary Stack,Secondary Stack,Players vs DST,Win %,Top 10%,Cash %,Proj. Own. Product,Proj. Own. Sum,ROI%,ROI$,Num Dupes\n"
                     f.write(header)
                     for lineup_str, fpts in unique.items():
                         f.write(f"{lineup_str}\n")
             else:
-                with open(out_path, "w") as f:
+                with open(lineups_path, "w") as f:
                     header = "Type,CPT,FLEX,FLEX,FLEX,FLEX,FLEX,Salary,Fpts Proj,Field Fpts Proj,Ceiling,Primary Stack,Secondary Stack,Players vs DST,Win %,Top 10%,Cash %,Proj. Own. Product,Proj. Own. Sum,Num Dupes\n"
                     f.write(header)
                     for lineup_str, fpts in unique.items():
                         f.write(f"{lineup_str}\n")
         else:
             if self.use_contest_data:
-                with open(out_path, "w") as f:
+                with open(lineups_path, "w") as f:
                     header = "Type,CPT,FLEX,FLEX,FLEX,FLEX,Salary,Fpts Proj,Field Fpts Proj,Ceiling,Primary Stack,Secondary Stack,Players vs DST,Win %,Top 10%,Cash %,Proj. Own. Product,Proj. Own. Sum,ROI,ROI/Entry Fee,Num Dupes\n"
                     f.write(header)
                     for lineup_str, fpts in unique.items():
                         f.write(f"{lineup_str}\n")
             else:
-                with open(out_path, "w") as f:
+                with open(lineups_path, "w") as f:
                     header = "Type,CPT,FLEX,FLEX,FLEX,FLEX,Salary,Fpts Proj,Field Fpts Proj,Ceiling,Primary Stack,Secondary Stack,Players vs DST,Win %,Top 10%,Cash %,Proj. Own. Product,Proj. Own. Sum,Num Dupes\n"
                     f.write(header)
                     for lineup_str, fpts in unique.items():
                         f.write(f"{lineup_str}\n")
-        self.player_output()
+        exposure_path = self.player_output()
+        return lineups_path, exposure_path

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html>
+  <head>
+    <title>NFL DFS Tools</title>
+  </head>
+  <body>
+    <h1>NFL DFS Tools</h1>
+
+    <h2>Optimize Lineups</h2>
+    <form action="/optimize" method="post">
+      <label>Site:</label>
+      <input name="site" placeholder="dk or fd" required><br>
+      <label>Number of Lineups:</label>
+      <input name="num_lineups" type="number" required><br>
+      <label>Number of Uniques:</label>
+      <input name="num_uniques" type="number" value="1" required><br>
+      <label>Mode:</label>
+      <select name="mode">
+        <option value="classic">Classic</option>
+        <option value="showdown">Showdown</option>
+      </select>
+      <button type="submit">Run Optimizer</button>
+    </form>
+
+    <h2>Simulate Tournament</h2>
+    <form action="/simulate" method="post">
+      <label>Site:</label>
+      <input name="site" placeholder="dk or fd" required><br>
+      <label>Field Size:</label>
+      <input name="field_size" type="number" required><br>
+      <label>Iterations:</label>
+      <input name="num_iterations" type="number" required><br>
+      <label>Mode:</label>
+      <select name="mode">
+        <option value="classic">Classic</option>
+        <option value="showdown">Showdown</option>
+      </select>
+      <button type="submit">Run Simulation</button>
+    </form>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask web app exposing optimizer and simulator tools
- return output file paths from optimization and simulation modules
- replace json5 dependency with Python's standard json module

## Testing
- `python -m py_compile app.py src/nfl_optimizer.py src/nfl_showdown_optimizer.py src/nfl_gpp_simulator.py src/nfl_showdown_simulator.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3cc2111e48330ae3f0f13f63de047