### PR TITLE
Add file upload and in-app results display

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ After you have the player data, you must import data from Awesemo, namely the pr
 
 ## Usage
 
+### Web Interface
+
+Run `python app.py` to start a local server. The homepage lets you upload projections, player IDs, and optional contest structure or config files. After uploading, you can run the optimizer or simulator and view the resulting tables directly in your browser.
+
+### Command Line
+
 To use the tools, you will need to open a windows console or powershell terminal in the same directory as this repository. To do this, go to the root directory and then navigate to `File > Open Windows Powershell` as seen below.
 
 ![Shell image](readme_images/shell.png)

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,6 +6,21 @@
   <body>
     <h1>NFL DFS Tools</h1>
 
+    <h2>Upload Required Files</h2>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+      <label>Site:</label>
+      <input name="site" placeholder="dk or fd" required><br>
+      <label>Projections:</label>
+      <input type="file" name="projections" required><br>
+      <label>Player IDs:</label>
+      <input type="file" name="players" required><br>
+      <label>Contest Structure (optional):</label>
+      <input type="file" name="contest"><br>
+      <label>Config (optional):</label>
+      <input type="file" name="config"><br>
+      <button type="submit">Upload Files</button>
+    </form>
+
     <h2>Optimize Lineups</h2>
     <form action="/optimize" method="post">
       <label>Site:</label>

--- a/templates/results.html
+++ b/templates/results.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+  <head>
+    <title>{{ title }}</title>
+    <style>
+      table, th, td {border:1px solid #000; border-collapse: collapse; padding:4px;}
+    </style>
+  </head>
+  <body>
+    <h1>{{ title }}</h1>
+    {% for name, table in tables %}
+      <h2>{{ name }}</h2>
+      {{ table|safe }}
+    {% endfor %}
+    <a href="/">Back</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Allow uploading projections, player IDs, contest structures, and config files from the web interface
- Render optimizer and simulator outputs directly in the browser
- Document web interface usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4734b0f048330978c3cef6142e4a3