### PR TITLE
Fix KeyError from stale team entries in optimizer

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -154,6 +154,12 @@ class NFL_Optimizer:
                     s["Name"]
                     + " name mismatch between projections and player ids, excluding from player_dict"
                 )
+                player, pos, team = p
+                if team in self.players_by_team and pos in self.players_by_team[team]:
+                    try:
+                        self.players_by_team[team][pos].remove(s)
+                    except ValueError:
+                        pass
                 self.player_dict.pop(p)
 
     # Load projections from file

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,42 @@
+import sys
+import os
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from nfl_optimizer import NFL_Optimizer
+
+
+def test_optimizer_handles_players_removed_from_player_dict():
+    opt = NFL_Optimizer(site="dk", num_lineups=1, num_uniques=1)
+
+    # choose an existing opponent team to ensure qb vs dst rule executes
+    opponent_team = next(iter(opt.players_by_team.keys()))
+
+    dummy_player = {
+        "Fpts": 10,
+        "Position": "QB",
+        "ID": 0,
+        "Salary": 5000,
+        "Name": "Dummy QB",
+        "Matchup": f"AAA @ {opponent_team}",
+        "Team": "AAA",
+        "Opponent": opponent_team,
+        "Ownership": 0,
+        "Ceiling": 15,
+        "StdDev": 3,
+    }
+
+    key = ("dummy qb", "QB", "AAA")
+    opt.player_dict[key] = dummy_player
+    if "AAA" not in opt.players_by_team:
+        opt.players_by_team["AAA"] = {"QB": [], "RB": [], "WR": [], "TE": [], "DST": []}
+    opt.players_by_team["AAA"]["QB"].append(dummy_player)
+
+    # Re-run assertion to remove players without ids
+    opt.assertPlayerDict()
+
+    # Ensure player removed from players_by_team
+    assert dummy_player not in opt.players_by_team["AAA"]["QB"]
+
+    # Should not raise KeyError
+    opt.optimize()


### PR DESCRIPTION
## Summary
- keep `players_by_team` in sync with `player_dict` when dropping players without IDs
- add regression test ensuring optimizer runs when a player is removed after ID mismatch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae7bc13e748330ac240c3456797019