### PR TITLE
Fix state leakage, respect minimum salary, and use uploaded files

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from src.nfl_gpp_simulator import NFL_GPP_Simulator
 from src.nfl_showdown_simulator import NFL_Showdown_Simulator
 
 app = Flask(__name__)
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 @app.route('/')
 def index():
@@ -15,7 +16,7 @@ def index():
 @app.route('/upload', methods=['POST'])
 def upload():
     site = request.form['site']
-    data_dir = f"{site}_data"
+    data_dir = os.path.join(BASE_DIR, f"{site}_data")
     os.makedirs(data_dir, exist_ok=True)
     projections = request.files.get('projections')
     players = request.files.get('players')
@@ -28,7 +29,7 @@ def upload():
     if contest and contest.filename:
         contest.save(os.path.join(data_dir, 'contest_structure.csv'))
     if config and config.filename:
-        config.save('config.json')
+        config.save(os.path.join(BASE_DIR, 'config.json'))
     return redirect('/')
 
 @app.route('/optimize', methods=['POST'])

--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -35,33 +35,6 @@ def salary_boost(salary, max_salary):
 
 
 class NFL_GPP_Simulator:
-    config = None
-    player_dict = {}
-    field_lineups = {}
-    stacks_dict = {}
-    gen_lineup_list = []
-    roster_construction = []
-    game_info = {}
-    id_name_dict = {}
-    salary = None
-    optimal_score = None
-    field_size = None
-    team_list = []
-    num_iterations = None
-    site = None
-    payout_structure = {}
-    use_contest_data = False
-    entry_fee = None
-    use_lineup_input = None
-    matchups = set()
-    projection_minimum = 15
-    randomness_amount = 100
-    min_lineup_salary = 48000
-    max_pct_off_optimal = 0.4
-    teams_dict = collections.defaultdict(list)  # Initialize teams_dict
-    correlation_rules = {}
-    seen_lineups = {}
-    seen_lineups_ix = {}
     position_map = {
         0: ["DST"],
         1: ["QB"],
@@ -82,8 +55,35 @@ class NFL_GPP_Simulator:
         use_contest_data,
         use_lineup_input,
     ):
+        # Instance attributes
+        self.config = None
+        self.player_dict = {}
+        self.field_lineups = {}
+        self.stacks_dict = {}
+        self.gen_lineup_list = []
+        self.roster_construction = []
+        self.game_info = {}
+        self.id_name_dict = {}
+        self.salary = None
+        self.optimal_score = None
+        self.field_size = None
+        self.team_list = []
+        self.num_iterations = None
         self.site = site
+        self.payout_structure = {}
+        self.use_contest_data = False
+        self.entry_fee = None
         self.use_lineup_input = use_lineup_input
+        self.matchups = set()
+        self.projection_minimum = 15
+        self.randomness_amount = 100
+        self.min_lineup_salary = 48000
+        self.max_pct_off_optimal = 0.4
+        self.teams_dict = collections.defaultdict(list)
+        self.correlation_rules = {}
+        self.seen_lineups = {}
+        self.seen_lineups_ix = {}
+
         self.load_config()
         self.load_rules()
 

--- a/src/nfl_showdown_optimizer.py
+++ b/src/nfl_showdown_optimizer.py
@@ -8,35 +8,35 @@ import itertools
 
 
 class NFL_Showdown_Optimizer:
-    site = None
-    config = None
-    problem = None
-    output_dir = None
-    num_lineups = None
-    num_uniques = None
-    team_list = []
-    players_by_team = {}
-    lineups = []
-    player_dict = {}
-    at_least = {}
-    at_most = {}
-    team_limits = {}
-    matchup_limits = {}
-    matchup_at_least = {}
-    stack_rules = {}
-    global_team_limit = 5
-    use_double_te = True
-    projection_minimum = 0
-    randomness_amount = 0
-    default_qb_var = 0.4
-    default_skillpos_var = 0.5
-    default_def_var = 0.5
     team_rename_dict = {"LA": "LAR"}
 
     def __init__(self, site=None, num_lineups=0, num_uniques=1):
         self.site = site
+        self.config = None
+        self.problem = None
+        self.output_dir = None
         self.num_lineups = int(num_lineups)
         self.num_uniques = int(num_uniques)
+        # Instance-scoped containers to avoid leaking state between runs
+        self.team_list = []
+        self.players_by_team = {}
+        self.lineups = []
+        self.player_dict = {}
+        self.at_least = {}
+        self.at_most = {}
+        self.team_limits = {}
+        self.matchup_limits = {}
+        self.matchup_at_least = {}
+        self.stack_rules = {}
+        self.global_team_limit = 5
+        self.use_double_te = True
+        self.projection_minimum = 0
+        self.randomness_amount = 0
+        self.default_qb_var = 0.4
+        self.default_skillpos_var = 0.5
+        self.default_def_var = 0.5
+        self.min_lineup_salary = 0
+
         self.load_config()
         self.load_rules()
 
@@ -141,6 +141,7 @@ class NFL_Showdown_Optimizer:
         self.stack_rules = self.config["stack_rules"]
         self.matchup_at_least = self.config["matchup_at_least"]
         self.matchup_limits = self.config["matchup_limits"]
+        self.min_lineup_salary = int(self.config.get("min_lineup_salary", 0))
         self.default_qb_var = (
             self.config["default_qb_var"] if "default_qb_var" in self.config else 0.333
         )
@@ -314,7 +315,11 @@ class NFL_Showdown_Optimizer:
 
         # Set the salary constraints
         max_salary = 50000 if self.site == "dk" else 60000
-        min_salary = 44000 if self.site == "dk" else 54000
+        min_salary = (
+            self.min_lineup_salary
+            if self.min_lineup_salary
+            else (44000 if self.site == "dk" else 54000)
+        )
         self.problem += (
             plp.lpSum(
                 self.player_dict[(player, pos_str, team)]["Salary"]

--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -25,31 +25,6 @@ def salary_boost(salary, max_salary):
     return (salary / max_salary) ** 2
 
 class NFL_Showdown_Simulator:
-    config = None
-    player_dict = {}
-    field_lineups = {}
-    stacks_dict = {}
-    gen_lineup_list = []
-    roster_construction = []
-    id_name_dict = {}
-    salary = None
-    optimal_score = None
-    field_size = None
-    team_list = []
-    num_iterations = None
-    site = None
-    payout_structure = {}
-    use_contest_data = False
-    entry_fee = None
-    use_lineup_input = None
-    matchups = set()
-    projection_minimum = 15
-    randomness_amount = 100
-    min_lineup_salary = 48000
-    max_pct_off_optimal = 0.4
-    teams_dict = collections.defaultdict(list)  # Initialize teams_dict
-    correlation_rules = {}
-
     def __init__(
         self,
         site,
@@ -58,8 +33,32 @@ class NFL_Showdown_Simulator:
         use_contest_data,
         use_lineup_input,
     ):
+        # Instance attributes
+        self.config = None
+        self.player_dict = {}
+        self.field_lineups = {}
+        self.stacks_dict = {}
+        self.gen_lineup_list = []
+        self.roster_construction = []
+        self.id_name_dict = {}
+        self.salary = None
+        self.optimal_score = None
+        self.field_size = None
+        self.team_list = []
+        self.num_iterations = None
         self.site = site
+        self.payout_structure = {}
+        self.use_contest_data = False
+        self.entry_fee = None
         self.use_lineup_input = use_lineup_input
+        self.matchups = set()
+        self.projection_minimum = 15
+        self.randomness_amount = 100
+        self.min_lineup_salary = 48000
+        self.max_pct_off_optimal = 0.4
+        self.teams_dict = collections.defaultdict(list)
+        self.correlation_rules = {}
+
         self.load_config()
         self.load_rules()
 


### PR DESCRIPTION
## Summary
- reset shared class state for optimizers and simulators to allow repeated runs without restarting the app
- enforce `min_lineup_salary` from config when building both classic and showdown lineups
- save uploaded files to repository root using absolute paths so optimizers and simulators read them correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af20673f448330a5fb686e8d31e629