### PR TITLE
Handle optional uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,9 +22,9 @@ def upload():
     players = request.files.get('players')
     contest = request.files.get('contest')
     config = request.files.get('config')
-    if projections:
+    if projections and projections.filename:
         projections.save(os.path.join(data_dir, 'projections.csv'))
-    if players:
+    if players and players.filename:
         players.save(os.path.join(data_dir, 'player_ids.csv'))
     if contest and contest.filename:
         contest.save(os.path.join(data_dir, 'contest_structure.csv'))

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,10 +10,10 @@
     <form action="/upload" method="post" enctype="multipart/form-data">
       <label>Site:</label>
       <input name="site" placeholder="dk or fd" required><br>
-      <label>Projections:</label>
-      <input type="file" name="projections" required><br>
-      <label>Player IDs:</label>
-      <input type="file" name="players" required><br>
+      <label>Projections (optional):</label>
+      <input type="file" name="projections"><br>
+      <label>Player IDs (optional):</label>
+      <input type="file" name="players"><br>
       <label>Contest Structure (optional):</label>
       <input type="file" name="contest"><br>
       <label>Config (optional):</label>


### PR DESCRIPTION
## Summary
- Avoid saving empty upload files so repo data remains available
- Make projections and player ID uploads optional in the UI

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af2d6d00f48330b60df1d1208695f7