### PR TITLE
Use pulp value for optimal score

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -455,11 +455,12 @@ class NFL_GPP_Simulator:
                     )
                 if s["ID"] is None:
                     print(s["Name"])
-        score = str(problem.objective)
-        for v in problem.variables():
-            score = score.replace(v.name, str(v.varValue))
-
-        self.optimal_score = eval(score)
+        # Directly evaluate the objective using PuLP's value helper instead of
+        # constructing a string and using ``eval``.  The previous approach would
+        # fail when any variable had a ``None`` value, causing a ``TypeError``
+        # during evaluation.  ``plp.value`` safely computes the objective value
+        # from the solved problem.
+        self.optimal_score = float(plp.value(problem.objective))
 
     @staticmethod
     def extract_matchup_time(game_string):


### PR DESCRIPTION
## Summary
- avoid using eval and compute optimal score with `pulp.value` to handle None variable values safely

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af417f89788330811a78202501c2da