### PR TITLE
Fix DraftKings player ID matching in GPP simulator

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -491,7 +491,7 @@ class NFL_GPP_Simulator:
                     position.sort()
                     if "QB" not in position and "DST" not in position:
                         position.append("FLEX")
-                    team = row["shortname"]
+                    team = row.get("team") or row.get("teamabbrev")
                     pos_str = str(position)
                     names = set()
                     for col in ["displayname", "firstname", "lastname", "shortname"]:
@@ -500,14 +500,29 @@ class NFL_GPP_Simulator:
                             names.add(val)
                     if row.get("firstname") and row.get("lastname"):
                         names.add(f"{row['firstname']} {row['lastname']}")
+                    matched = False
                     for name in names:
                         player_name = name.replace("-", "#").lower().strip()
-                        key = (player_name, pos_str, team)
-                        if key in self.player_dict:
-                            self.player_dict[key]["ID"] = str(row["draftableid"])
-                            self.player_dict[key]["Team"] = team
-                            self.player_dict[key]["Opp"] = ""
-                            self.player_dict[key]["Matchup"] = ()
+                        if team:
+                            key = (player_name, pos_str, team)
+                            if key in self.player_dict:
+                                self.player_dict[key]["ID"] = str(row["draftableid"])
+                                self.player_dict[key]["Team"] = team
+                                self.player_dict[key]["Opp"] = ""
+                                self.player_dict[key]["Matchup"] = ()
+                                matched = True
+                                break
+                        else:
+                            for key in list(self.player_dict.keys()):
+                                pname, ppos, pteam = key
+                                if pname == player_name and ppos == pos_str:
+                                    self.player_dict[key]["ID"] = str(row["draftableid"])
+                                    self.player_dict[key]["Team"] = pteam
+                                    self.player_dict[key]["Opp"] = ""
+                                    self.player_dict[key]["Matchup"] = ()
+                                    matched = True
+                                    break
+                        if matched:
                             break
                     self.id_name_dict[str(row["draftableid"])] = row.get("displayname", "")
                 else:

--- a/tests/test_gpp_simulator.py
+++ b/tests/test_gpp_simulator.py
@@ -1,0 +1,26 @@
+import sys, os
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from nfl_gpp_simulator import NFL_GPP_Simulator
+
+
+def test_lamar_jackson_gets_id_without_mismatch(monkeypatch, capsys):
+    # Avoid heavy optimizer/correlation work in tests
+    monkeypatch.setattr(NFL_GPP_Simulator, "get_optimal", lambda self: None)
+    monkeypatch.setattr(NFL_GPP_Simulator, "load_correlation_rules", lambda self: None)
+
+    sim = NFL_GPP_Simulator(
+        site="dk",
+        field_size=10,
+        num_iterations=1,
+        use_contest_data=False,
+        use_lineup_input=False,
+    )
+
+    captured = capsys.readouterr()
+    assert "lamar jackson name mismatch" not in captured.out.lower()
+
+    key = ("lamar jackson", str(["QB"]), "BAL")
+    assert key in sim.player_dict
+    assert sim.player_dict[key]["ID"] not in ("", None, 0)


### PR DESCRIPTION
## Summary
- Align GPP simulator player ID matching with optimizer logic
- Add regression test ensuring Lamar Jackson gets matched without warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af4595444083309051ed7cb866ffd7