### PR TITLE
Add lineup generation guards and simulator UI options

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -843,10 +843,7 @@ class NFL_GPP_Simulator:
     def load_lineups_from_file(self):
         print("loading lineups")
         i = 0
-        path = os.path.join(
-            os.path.dirname(__file__),
-            "../{}_data/{}".format(self.site, "tournament_lineups.csv"),
-        )
+        path = get_data_path(self.site, "tournament_lineups.csv")
         with open(path) as file:
             reader = pd.read_csv(file)
             lineup = []
@@ -977,6 +974,7 @@ class NFL_GPP_Simulator:
             in_lineup.fill(0)
         reject = True
         iteration_count = 0
+        max_iterations = 5000
         total_players = num_players_in_roster
         issue = ""
         complete = ""
@@ -995,6 +993,10 @@ class NFL_GPP_Simulator:
         # print(lu_num, ' started',  team_stack, max_stack_len)
         while reject:
             iteration_count += 1
+            if iteration_count > max_iterations:
+                raise RuntimeError(
+                    f"Failed to generate lineup after {max_iterations} iterations"
+                )
             if team_stack == "":
                 salary = 0
                 proj = 0

--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -694,10 +694,7 @@ class NFL_Showdown_Simulator:
     def load_lineups_from_file(self):
         print("loading lineups")
         i = 0
-        path = os.path.join(
-            os.path.dirname(__file__),
-            "../{}_data/{}".format(self.site, "tournament_lineups.csv"),
-        )
+        path = get_data_path(self.site, "tournament_lineups.csv")
         with open(path) as file:
             reader = pd.read_csv(file)
             lineup = []
@@ -869,8 +866,13 @@ class NFL_Showdown_Simulator:
         lus = {}
         in_lineup.fill(0)
         iteration_count = 0
+        max_iterations = 5000
         while True:
             iteration_count += 1
+            if iteration_count > max_iterations:
+                raise RuntimeError(
+                    f"Failed to generate lineup after {max_iterations} iterations"
+                )
             salary, proj = 0, 0
             lineup, player_teams, lineup_matchups = [], [], []
             def_opp, players_opposing_def, cpt_selected = None, 0, False

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,6 +42,7 @@
         <option value="classic">Classic</option>
         <option value="showdown">Showdown</option>
       </select>
+      <label><input type="checkbox" name="save_lineups"> Save lineups for simulator</label><br>
       <button type="submit">Run Optimizer</button>
     </form>
 
@@ -58,6 +59,8 @@
         <option value="classic">Classic</option>
         <option value="showdown">Showdown</option>
       </select>
+      <label><input type="checkbox" name="use_contest_data"> Use contest structure</label><br>
+      <label><input type="checkbox" name="use_lineup_input"> Use saved lineups</label><br>
       <button type="submit">Run Simulation</button>
     </form>
   </body>


### PR DESCRIPTION
## Summary
- Prevent infinite loops in lineup generation with max-iteration guards in GPP and Showdown simulators
- Support uploaded lineup files via `get_data_path` and allow optimizer to save lineups for later simulation
- Expose contest data and lineup usage toggles in both Flask and Streamlit UIs, plus ability to save optimizer output as tournament lineups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af5525bf2483308de2dc5c8dc05a6c