### PR TITLE
Gracefully handle lineup generation failures

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -994,9 +994,10 @@ class NFL_GPP_Simulator:
         while reject:
             iteration_count += 1
             if iteration_count > max_iterations:
-                raise RuntimeError(
+                print(
                     f"Failed to generate lineup after {max_iterations} iterations"
                 )
+                return {}
             if team_stack == "":
                 salary = 0
                 proj = 0
@@ -1756,10 +1757,14 @@ class NFL_GPP_Simulator:
                 pool.close()
                 pool.join()
             print("pool closed")
-            self.update_field_lineups(output,diff)
+            valid_output = [o for o in output if o]
+            failed = len(output) - len(valid_output)
+            if failed:
+                print(f"{failed} lineups failed to generate and were skipped")
+            self.update_field_lineups(valid_output, len(valid_output))
             end_time = time.time()
             print("lineups took " + str(end_time - start_time) + " seconds")
-            print(str(diff) + " field lineups successfully generated")
+            print(str(len(valid_output)) + " field lineups successfully generated")
             # print("Reject counters:", dict(overall_reject_counters))
 
             # print(self.field_lineups)

--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -870,9 +870,10 @@ class NFL_Showdown_Simulator:
         while True:
             iteration_count += 1
             if iteration_count > max_iterations:
-                raise RuntimeError(
+                print(
                     f"Failed to generate lineup after {max_iterations} iterations"
                 )
+                return {}
             salary, proj = 0, 0
             lineup, player_teams, lineup_matchups = [], [], []
             def_opp, players_opposing_def, cpt_selected = None, 0, False
@@ -1004,12 +1005,17 @@ class NFL_Showdown_Simulator:
 
         print("pool closed")
 
+        valid_output = [o for o in output if o]
+        failed = len(output) - len(valid_output)
+        if failed:
+            print(f"{failed} lineups failed to generate and were skipped")
+
         # Update field lineups
-        self.update_field_lineups(output, diff)
+        self.update_field_lineups(valid_output, len(valid_output))
 
         end_time = time.time()
         print(f"lineups took {end_time - start_time} seconds")
-        print(f"{diff} field lineups successfully generated")
+        print(f"{len(valid_output)} field lineups successfully generated")
 
     def extract_player_data(self):
         ids, ownership, salaries, projections, teams, opponents, matchups, positions = (


### PR DESCRIPTION
## Summary
- Avoid raising RuntimeError in lineup generation when iteration limit is hit and skip the lineup instead
- Filter out failed lineups after multiprocessing to keep simulation running
- Apply the same failure handling to showdown simulator

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af641e013c833087a5c652364b9368