### PR TITLE
Add configuration toggles for TE stacks and bring-backs

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,8 @@
     "player_path": "player_ids.csv",
     "contest_structure_path": "contest_structure.csv",
     "use_double_te": false,
+    "use_te_stack": true,
+    "require_bring_back": true,
     "global_team_limit": 4,
     "projection_minimum": 5,
     "randomness": 25,

--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -85,6 +85,8 @@ class NFL_GPP_Simulator:
         self.correlation_rules = {}
         self.seen_lineups = {}
         self.seen_lineups_ix = {}
+        self.use_te_stack = True
+        self.require_bring_back = True
 
         self.load_config()
         self.load_rules()
@@ -178,6 +180,8 @@ class NFL_GPP_Simulator:
         self.overlap_limit = float(self.config["num_players_vs_def"])
         self.pct_field_double_stacks = float(self.config["pct_field_double_stacks"])
         self.correlation_rules = self.config["custom_correlations"]
+        self.use_te_stack = bool(self.config.get("use_te_stack", True))
+        self.require_bring_back = bool(self.config.get("require_bring_back", True))
 
     def assertPlayerDict(self):
         for p, s in list(self.player_dict.items()):
@@ -980,6 +984,8 @@ class NFL_GPP_Simulator:
         matchups,
         num_players_in_roster,
         site,
+        use_te_stack,
+        require_bring_back,
     ):
         # new random seed for each lineup (without this there is a ton of dupes)
         rng = np.random.Generator(np.random.PCG64())
@@ -1316,11 +1322,21 @@ class NFL_GPP_Simulator:
                 lineup[1] = ids[qb]
                 in_lineup[qb] = 1
                 lineup_matchups.append(matchups[qb])
-                valid_players = np.unique(
-                    valid_team[np.nonzero(pos_matrix[valid_team, 4:8] > 0)[0]]
-                )
+                if use_te_stack:
+                    valid_players = np.unique(
+                        valid_team[
+                            np.nonzero(pos_matrix[valid_team, 4:8] > 0)[0]
+                        ]
+                    )
+                else:
+                    valid_players = np.unique(
+                        valid_team[
+                            np.nonzero(pos_matrix[valid_team, 4:7] > 0)[0]
+                        ]
+                    )
                 player_teams.append(teams[qb])
                 players_opposing_def = 0
+                opp_team = opponents[qb]
                 plyr_list = ids[valid_players]
                 prob_list = ownership[valid_players]
                 prob_list = prob_list / prob_list.sum()
@@ -1373,9 +1389,20 @@ class NFL_GPP_Simulator:
                 for ix, (l, pos) in enumerate(zip(lineup, pos_matrix.T)):
                     if l == "0.0":
                         if k < 1:
-                            valid_players = np.nonzero(
-                                (pos > 0) & (in_lineup == 0) & (opponents != team_stack)
-                            )[0]
+                            if require_bring_back:
+                                valid_players = np.nonzero(
+                                    (pos > 0)
+                                    & (in_lineup == 0)
+                                    & (teams == opp_team)
+                                )[0]
+                                if valid_players.size == 0:
+                                    valid_players = np.nonzero(
+                                        (pos > 0) & (in_lineup == 0)
+                                    )[0]
+                            else:
+                                valid_players = np.nonzero(
+                                    (pos > 0) & (in_lineup == 0)
+                                )[0]
                             # grab names of players eligible
                             plyr_list = ids[valid_players]
                             # create np array of probability of being selected based on ownership and who is eligible at the position
@@ -1764,6 +1791,8 @@ class NFL_GPP_Simulator:
                     matchups,
                     num_players_in_roster,
                     self.site,
+                    self.use_te_stack,
+                    self.require_bring_back,
                 )
                 problems.append(lu_tuple)
             start_time = time.time()

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -40,6 +40,8 @@ class NFL_Optimizer:
         self.stack_rules = {}
         self.global_team_limit = None
         self.use_double_te = True
+        self.use_te_stack = True
+        self.require_bring_back = True
         self.projection_minimum = 0
         self.randomness_amount = 0
         self.default_qb_var = 0.4
@@ -140,7 +142,21 @@ class NFL_Optimizer:
         self.projection_minimum = int(self.config["projection_minimum"])
         self.randomness_amount = float(self.config["randomness"])
         self.use_double_te = bool(self.config["use_double_te"])
-        self.stack_rules = self.config["stack_rules"]
+        self.use_te_stack = bool(self.config.get("use_te_stack", True))
+        self.require_bring_back = bool(self.config.get("require_bring_back", True))
+        self.stack_rules = copy.deepcopy(self.config["stack_rules"])
+        if not self.use_te_stack:
+            for rule in self.stack_rules.get("pair", []):
+                if rule.get("key") == "QB" and rule.get("type") == "same-team":
+                    rule["positions"] = [
+                        pos for pos in rule.get("positions", []) if pos != "TE"
+                    ]
+        if not self.require_bring_back:
+            self.stack_rules["pair"] = [
+                r
+                for r in self.stack_rules.get("pair", [])
+                if r.get("type") != "opp-team"
+            ]
         self.matchup_at_least = self.config["matchup_at_least"]
         self.matchup_limits = self.config["matchup_limits"]
         self.allow_qb_vs_dst = bool(self.config["allow_qb_vs_dst"])


### PR DESCRIPTION
## Summary
- Add `use_te_stack` and `require_bring_back` options to configuration
- Make optimizer stack rules honor TE stack and bring-back flags
- Update GPP simulator lineup generation to respect new stack settings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24177c2908330a4c857d901046452