### PR TITLE
Add configuration flags for stack constraints

### DIFF
--- a/config.json
+++ b/config.json
@@ -11,10 +11,13 @@
     "num_players_vs_def" : 0,
     "pct_field_using_stacks" : 0.65, 
     "pct_field_double_stacks": 0.4,
-    "default_qb_var" : 0.4, 
-    "default_skillpos_var" : 0.5, 
+    "default_qb_var" : 0.4,
+    "default_skillpos_var" : 0.5,
     "default_def_var" : 0.5,
     "allow_qb_vs_dst": false,
+    "allow_qb_double_stack": false,
+    "allow_qb_rb_stack": false,
+    "allow_rb_wr_same_team": false,
     "at_most": {
         "1": []
     },

--- a/sample.config.json
+++ b/sample.config.json
@@ -12,9 +12,12 @@
     "pct_field_using_stacks" : 0.65, 
     "pct_field_double_stacks": 0.4,
     "default_qb_var" : 0.4, 
-    "default_skillpos_var" : 0.5, 
+    "default_skillpos_var" : 0.5,
     "default_def_var" : 0.5,
     "allow_qb_vs_dst": false,
+    "allow_qb_double_stack": true,
+    "allow_qb_rb_stack": true,
+    "allow_rb_wr_same_team": true,
     "at_most": {
         "1": [["Ezekiel Elliott", "Tony Pollard"]]
     },


### PR DESCRIPTION
## Summary
- add configuration options to control QB double stacks, QB+RB stacks, and RB+WR stacks
- apply new flags in optimizer rule loading to adjust stack and limit rules
- document new options in sample.config.json

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b24170c9048330a81d64f86a3d0e8a