### PR TITLE
Fix stack metrics player info lookup and add analyze_lineup tests

### DIFF
--- a/src/stack_metrics.py
+++ b/src/stack_metrics.py
@@ -18,7 +18,8 @@ def detect_presence(lineup: List[str], player_dict: Dict) -> Dict[str, int]:
     qb_team = None
     opp_team = None
     for key in lineup:
-
+        info = player_dict.get(key)
+        if info and info.get("Position") == "QB":
             qb_team = info["Team"]
             opp_team = info.get("Opponent")
             break
@@ -27,9 +28,12 @@ def detect_presence(lineup: List[str], player_dict: Dict) -> Dict[str, int]:
     te_by_team = defaultdict(list)
     rb_by_team = defaultdict(list)
     for key in lineup:
+        info = player_dict.get(key)
+        if not info:
+            continue
 
-        pos = info["Position"]
-        team = info["Team"]
+        pos = info.get("Position")
+        team = info.get("Team")
         if pos == "WR":
             wr_by_team[team].append(key)
         elif pos == "TE":
@@ -78,7 +82,8 @@ def count_multiplicity(lineup: List[str], player_dict: Dict) -> Dict[str, int]:
     qb_team = None
     opp_team = None
     for key in lineup:
-
+        info = player_dict.get(key)
+        if info and info.get("Position") == "QB":
             qb_team = info["Team"]
             opp_team = info.get("Opponent")
             break
@@ -87,9 +92,12 @@ def count_multiplicity(lineup: List[str], player_dict: Dict) -> Dict[str, int]:
     te_by_team = defaultdict(list)
     rb_by_team = defaultdict(list)
     for key in lineup:
+        info = player_dict.get(key)
+        if not info:
+            continue
 
-        pos = info["Position"]
-        team = info["Team"]
+        pos = info.get("Position")
+        team = info.get("Team")
         if pos == "WR":
             wr_by_team[team].append(key)
         elif pos == "TE":
@@ -136,7 +144,8 @@ def exclusive_bucket(lineup: List[str], player_dict: Dict) -> str:
     qb_team = None
     opp_team = None
     for key in lineup:
-
+        info = player_dict.get(key)
+        if info and info.get("Position") == "QB":
             qb_team = info["Team"]
             opp_team = info.get("Opponent")
             break
@@ -145,9 +154,12 @@ def exclusive_bucket(lineup: List[str], player_dict: Dict) -> str:
     te_by_team = defaultdict(list)
     rb_by_team = defaultdict(list)
     for key in lineup:
+        info = player_dict.get(key)
+        if not info:
+            continue
 
-        pos = info["Position"]
-        team = info["Team"]
+        pos = info.get("Position")
+        team = info.get("Team")
         if pos == "WR":
             wr_by_team[team].append(key)
         elif pos == "TE":

--- a/tests/test_stack_metrics.py
+++ b/tests/test_stack_metrics.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+from stack_metrics import analyze_lineup
+
+
+def test_analyze_lineup_identifies_stacks_and_counts():
+    player_dict = {
+        "QB_A": {"Position": "QB", "Team": "A", "Opponent": "B"},
+        "WR_A1": {"Position": "WR", "Team": "A", "Opponent": "B"},
+        "WR_A2": {"Position": "WR", "Team": "A", "Opponent": "B"},
+        "WR_B1": {"Position": "WR", "Team": "B", "Opponent": "A"},
+        "TE_B1": {"Position": "TE", "Team": "B", "Opponent": "A"},
+        "RB_A1": {"Position": "RB", "Team": "A", "Opponent": "B"},
+    }
+    lineup = list(player_dict.keys())
+
+    result = analyze_lineup(lineup, player_dict)
+
+    assert result["presence"]["QB+WR"] == 1
+    assert result["presence"]["QB+WR+WR+OppWR"] == 1
+    assert result["presence"]["RB+WR same-team"] == 1
+    assert result["counts"]["QB+WR"] == 2
+    assert result["counts"]["QB+WR+OppWR"] == 2
+    assert result["bucket"] == "QB+WR+WR+OppWR"
+
+
+def test_analyze_lineup_no_stack_bucket():
+    player_dict = {
+        "QB_A": {"Position": "QB", "Team": "A", "Opponent": "B"},
+        "WR_C1": {"Position": "WR", "Team": "C", "Opponent": "D"},
+        "RB_E1": {"Position": "RB", "Team": "E", "Opponent": "F"},
+        "TE_G1": {"Position": "TE", "Team": "G", "Opponent": "H"},
+    }
+    lineup = list(player_dict.keys())
+
+    result = analyze_lineup(lineup, player_dict)
+
+    assert result["presence"]["No Stack"] == 1
+    assert result["counts"]["No Stack"] == 1
+    assert result["bucket"] == "No Stack"


### PR DESCRIPTION
## Summary
- handle player info lookup in stack metrics to avoid `NameError`
- add unit tests for `analyze_lineup` covering stack detection and no-stack case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b27356b0248330bda65f215e5513fa