### PR TITLE
Ensure opponent data passed to analyze_lineup

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -2320,7 +2320,10 @@ class NFL_GPP_Simulator:
         )
 
     def output(self):
-        id_player_dict = {v["ID"]: v for v in self.player_dict.values()}
+        id_player_dict = {
+            v["ID"]: {**v, "Opponent": v.get("Opponent") or v.get("Opp")}
+            for v in self.player_dict.values()
+        }
         unique = {}
         for index, x in self.field_lineups.items():
             # if index == 0:


### PR DESCRIPTION
## Summary
- include opponent info in player dictionaries when outputting so stack analysis has required context
- test GPP simulator output to verify stack columns and opponent data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b27e9664c4833089ad2d0dcfd52475