### PR TITLE
Add players vs DST count to optimizer output

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -975,9 +975,11 @@ class NFL_Optimizer:
         )
         out_path = os.path.join(os.path.dirname(__file__), filename_out)
         with open(out_path, "w") as f:
-            f.write(
-                "QB,RB,RB,WR,WR,WR,TE,FLEX,DST,Salary,Fpts Proj,Fpts Used,Fpts Act,Ceiling,Own. Sum,Own. Product,STDDEV,Stack\n"
+            header = (
+                "QB,RB,RB,WR,WR,WR,TE,FLEX,DST,Salary,Fpts Proj,Fpts Used,Fpts Act,Ceiling,"
+                "Own. Sum,Own. Product,STDDEV,Players vs DST,Stack\n"
             )
+            f.write(header)
             for x, fpts_used in sorted_lineups:
                 stack_str = self.construct_stack_string(x)
 
@@ -990,6 +992,19 @@ class NFL_Optimizer:
                 )
                 ceil = sum([self.player_dict[player]["Ceiling"] for player in x])
                 stddev = sum([self.player_dict[player]["StdDev"] for player in x])
+
+                dst_opponents = {
+                    self.player_dict[p].get("Opponent")
+                    for p in x
+                    if self.player_dict[p]["Position"] == "DST"
+                    and self.player_dict[p].get("Opponent")
+                }
+                players_vs_def = sum(
+                    1
+                    for p in x
+                    if self.player_dict[p]["Position"] != "DST"
+                    and self.player_dict[p].get("Team") in dst_opponents
+                )
                 if self.site == "dk":
                     player_fields = [
                         f"{self.player_dict[p]['Name']} ({self.player_dict[p]['ID']})" for p in x
@@ -1007,6 +1022,7 @@ class NFL_Optimizer:
                     own_s,
                     own_p,
                     stddev,
+                    players_vs_def,
                     stack_str,
                 ]
                 lineup_str = ",".join(map(str, fields))

--- a/tests/test_optimizer_stack_output.py
+++ b/tests/test_optimizer_stack_output.py
@@ -6,11 +6,13 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 from nfl_optimizer import NFL_Optimizer
 
 
-def test_output_includes_stack_column():
+def test_output_includes_players_vs_dst_column():
     opt = NFL_Optimizer(site="dk", num_lineups=1, num_uniques=1)
     opt.optimize()
     path = opt.output()
     with open(path) as f:
         rows = list(csv.reader(f))
+    assert rows[0][-2] == "Players vs DST"
     assert rows[0][-1] == "Stack"
+    assert rows[1][-2].isdigit()
     assert rows[1][-1] != ""


### PR DESCRIPTION
## Summary
- Include players-vs-DST count in optimizer CSV output header and rows
- Track DST opponents and count opposing team players in each lineup
- Test that new column exists and contains numeric value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b30358d8948330933bd0ff9f26f498