### PR TITLE
Add lineup generation progress counter

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -885,8 +885,9 @@ class NFL_Optimizer:
             fpts_used = self.problem.objective.value()
             self.lineups.append((players, fpts_used))
 
-            if i % 100 == 0:
-                print(i)
+            progress = i + 1
+            percent = (progress / num_pool) * 100
+            print(f"{progress}/{num_pool} {percent:.0f}%")
 
             # Ensure this lineup isn't picked again
             self.problem += (

--- a/src/nfl_showdown_optimizer.py
+++ b/src/nfl_showdown_optimizer.py
@@ -737,8 +737,9 @@ class NFL_Showdown_Optimizer:
             fpts_used = self.problem.objective.value()
             self.lineups.append((players, fpts_used))
 
-            if i % 100 == 0:
-                print(i)
+            progress = i + 1
+            percent = (progress / self.num_lineups) * 100
+            print(f"{progress}/{self.num_lineups} {percent:.0f}%")
 
             # Ensure this lineup isn't picked again
             self.problem += (


### PR DESCRIPTION
## Summary
- Display real-time lineup generation progress in main optimizer
- Show progress counter in showdown optimizer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b309f8c5588330b0b02c945b3b4506