### PR TITLE
Add lineup generation progress to web UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,8 @@
 import os
 import shutil
+import threading
 import pandas as pd
-from flask import Flask, render_template, request, redirect
+from flask import Flask, render_template, request, redirect, jsonify
 from src.nfl_optimizer import NFL_Optimizer
 from src.nfl_showdown_optimizer import NFL_Showdown_Optimizer
 from src.nfl_gpp_simulator import NFL_GPP_Simulator
@@ -10,6 +11,25 @@ from src.nfl_showdown_simulator import NFL_Showdown_Simulator
 app = Flask(__name__)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 UPLOAD_DIR = os.path.join(BASE_DIR, "uploads")
+
+progress_data = {"current": 0, "total": 0, "percent": 0, "status": "idle", "output_path": None}
+
+
+def update_progress(current, total):
+    progress_data["current"] = current
+    progress_data["total"] = total
+    progress_data["percent"] = int((current / total) * 100)
+
+
+def run_optimizer(opto, site, save_lineups):
+    opto.optimize(progress_callback=update_progress)
+    output_path = opto.output()
+    if save_lineups:
+        dest_dir = os.path.join(UPLOAD_DIR, site)
+        os.makedirs(dest_dir, exist_ok=True)
+        shutil.copy(output_path, os.path.join(dest_dir, "tournament_lineups.csv"))
+    progress_data["output_path"] = output_path
+    progress_data["status"] = "done"
 
 @app.route('/')
 def index():
@@ -47,16 +67,15 @@ def optimize():
         opto = NFL_Showdown_Optimizer(site, num_lineups, num_uniques)
     else:
         opto = NFL_Optimizer(site, num_lineups, num_uniques)
-    opto.optimize()
-    output_path = opto.output()
-    if save_lineups:
-        dest_dir = os.path.join(UPLOAD_DIR, site)
-        os.makedirs(dest_dir, exist_ok=True)
-        shutil.copy(output_path, os.path.join(dest_dir, 'tournament_lineups.csv'))
-    # Only load the first 1000 lineups for display to avoid rendering huge tables
-    df = pd.read_csv(output_path, nrows=1000)
-    tables = [("Lineups (first 1000)", df.to_html(index=False))]
-    return render_template('results.html', title='Optimization Results', tables=tables)
+
+    total = opto.num_lineups
+
+    progress_data.update({'current': 0, 'total': total, 'percent': 0, 'status': 'running', 'output_path': None})
+
+    thread = threading.Thread(target=run_optimizer, args=(opto, site, save_lineups))
+    thread.start()
+
+    return render_template('progress.html')
 
 @app.route('/simulate', methods=['POST'])
 def simulate():
@@ -96,6 +115,20 @@ def reset():
     if os.path.exists(config_path):
         os.remove(config_path)
     return redirect('/')
+
+
+@app.route('/progress')
+def progress():
+    return jsonify(progress_data)
+
+
+@app.route('/results')
+def results():
+    if not progress_data.get('output_path'):
+        return redirect('/')
+    df = pd.read_csv(progress_data['output_path'], nrows=1000)
+    tables = [("Lineups (first 1000)", df.to_html(index=False))]
+    return render_template('results.html', title='Optimization Results', tables=tables)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -296,7 +296,7 @@ class NFL_Optimizer:
                     self.player_dict[(player_name, position, team)]
                 )
 
-    def optimize(self):
+    def optimize(self, progress_callback=None):
         # Setup our linear programming equation - https://en.wikipedia.org/wiki/Linear_programming
         # We will use PuLP as our solver - https://coin-or.github.io/pulp/
 
@@ -885,8 +885,13 @@ class NFL_Optimizer:
             fpts_used = self.problem.objective.value()
             self.lineups.append((players, fpts_used))
 
-            if i % 100 == 0:
-                print(i)
+            progress = i + 1
+            display_progress = min(progress, self.num_lineups)
+            percent = (display_progress / self.num_lineups) * 100
+            if progress_callback:
+                progress_callback(display_progress, self.num_lineups)
+            else:
+                print(f"{display_progress}/{self.num_lineups} {percent:.0f}%")
 
             # Ensure this lineup isn't picked again
             self.problem += (

--- a/src/nfl_showdown_optimizer.py
+++ b/src/nfl_showdown_optimizer.py
@@ -270,7 +270,7 @@ class NFL_Showdown_Optimizer:
                     self.player_dict[(player_name, "FLEX", team)]
                 )
 
-    def optimize(self):
+    def optimize(self, progress_callback=None):
         # Setup our linear programming equation - https://en.wikipedia.org/wiki/Linear_programming
         # We will use PuLP as our solver - https://coin-or.github.io/pulp/
 
@@ -737,8 +737,12 @@ class NFL_Showdown_Optimizer:
             fpts_used = self.problem.objective.value()
             self.lineups.append((players, fpts_used))
 
-            if i % 100 == 0:
-                print(i)
+            progress = i + 1
+            percent = (progress / self.num_lineups) * 100
+            if progress_callback:
+                progress_callback(progress, self.num_lineups)
+            else:
+                print(f"{progress}/{self.num_lineups} {percent:.0f}%")
 
             # Ensure this lineup isn't picked again
             self.problem += (

--- a/templates/progress.html
+++ b/templates/progress.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Optimization Progress</title>
+    <script>
+      async function poll() {
+        const res = await fetch('/progress');
+        const data = await res.json();
+        document.getElementById('status').innerText = `${data.current}/${data.total} ${data.percent}%`;
+        if (data.status === 'done') {
+          window.location.href = '/results';
+        } else {
+          setTimeout(poll, 1000);
+        }
+      }
+      window.onload = poll;
+    </script>
+  </head>
+  <body>
+    <h1>Generating Lineups...</h1>
+    <div id="status">0/0 0%</div>
+    <a href="/">Back</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Expose optimizer progress via callback to report lineup generation status
- Track progress in Flask app and provide `/progress` polling endpoint and `/results` route
- Add progress page that polls server and redirects to final results
- Report progress against requested lineup total so counts and percentages reflect user input

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b309f8c5588330b0b02c945b3b4506