### PR TITLE
Add console progress logging for lineup generation

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -886,6 +886,11 @@ class NFL_Optimizer:
             self.lineups.append((players, fpts_used))
 
             progress = i + 1
+            if progress % 25 == 0 or progress == num_pool:
+                percent = (progress / num_pool) * 100
+                print(
+                    f"Generated lineup {progress}/{num_pool} ({percent:.2f}% complete)"
+                )
 
 
             # Ensure this lineup isn't picked again

--- a/src/nfl_showdown_optimizer.py
+++ b/src/nfl_showdown_optimizer.py
@@ -738,8 +738,11 @@ class NFL_Showdown_Optimizer:
             self.lineups.append((players, fpts_used))
 
             progress = i + 1
-            percent = (progress / self.num_lineups) * 100
-
+            if progress % 25 == 0 or progress == self.num_lineups:
+                percent = (progress / self.num_lineups) * 100
+                print(
+                    f"Generated lineup {progress}/{self.num_lineups} ({percent:.2f}% complete)"
+                )
 
             # Ensure this lineup isn't picked again
             self.problem += (


### PR DESCRIPTION
## Summary
- print lineup generation progress in `nfl_optimizer` and `nfl_showdown_optimizer` every 25 lineups

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b314fa60f08330807289e085d3931f