### PR TITLE
Add stack exposure reporting across optimizer and simulator

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -23,7 +23,7 @@ import datetime
 
 from utils import get_data_path, get_config_path
 from stack_metrics import analyze_lineup
-from selection_exposures import select_lineups
+from selection_exposures import select_lineups, report_lineup_exposures
 
 @jit(nopython=True)
 def salary_boost(salary, max_salary):
@@ -1918,26 +1918,11 @@ class NFL_GPP_Simulator:
             # print(self.field_lineups)
 
         if self.profile and self.targets:
-
-            presence_tot = Counter()
-            mult_tot = Counter()
-            bucket_tot = Counter()
-            for lu in selected:
-
-                presence_tot.update(m["presence"])
-                mult_tot.update(m["counts"])
-                bucket_tot[m["bucket"]] += 1
-            n = len(selected)
-            print("Exposure Results:")
-            for k, t in self.targets.get("presence_targets_pct", {}).items():
-                ach = presence_tot.get(k, 0) / n if n else 0
-                print(f"Presence {k}: {ach:.2f} (target {t:.2f})")
-            for k, t in self.targets.get("multiplicity_targets_mean", {}).items():
-                ach = mult_tot.get(k, 0) / n if n else 0
-                print(f"Multiplicity {k}: {ach:.2f} (target {t:.2f})")
-            for k, t in self.targets.get("bucket_mix_pct", {}).items():
-                ach = bucket_tot.get(k, 0) / n if n else 0
-                print(f"Bucket {k}: {ach:.2f} (target {t:.2f})")
+            candidates = [v["Lineup"] for v in self.field_lineups.values()]
+            selected = select_lineups(
+                candidates, self.player_dict, self.targets, self.field_size
+            )
+            report_lineup_exposures(selected, self.player_dict, self.targets)
             self.field_lineups = {}
             self.seen_lineups = {}
             self.seen_lineups_ix = {}

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -9,10 +9,9 @@ import pulp as plp
 import copy
 import itertools
 from random import shuffle, choice
-from collections import Counter
 
 from utils import get_data_path, get_config_path
-from selection_exposures import select_lineups
+from selection_exposures import select_lineups, report_lineup_exposures
 from stack_metrics import analyze_lineup
 
 
@@ -936,25 +935,7 @@ class NFL_Optimizer:
                     for (players, fpts) in self.lineups
                     if tuple(players) in selected_set
                 ]
-                presence_tot = Counter()
-                mult_tot = Counter()
-                bucket_tot = Counter()
-                for lineup in selected_players:
-                    metrics = analyze_lineup(lineup, self.player_dict)
-                    presence_tot.update(metrics["presence"])
-                    mult_tot.update(metrics["counts"])
-                    bucket_tot[metrics["bucket"]] += 1
-                n = len(selected_players)
-                print("Exposure Results:")
-                for k, t in targets.get("presence_targets_pct", {}).items():
-                    ach = presence_tot.get(k, 0) / n if n else 0
-                    print(f"Presence {k}: {ach:.2f} (target {t:.2f})")
-                for k, t in targets.get("multiplicity_targets_mean", {}).items():
-                    ach = mult_tot.get(k, 0) / n if n else 0
-                    print(f"Multiplicity {k}: {ach:.2f} (target {t:.2f})")
-                for k, t in targets.get("bucket_mix_pct", {}).items():
-                    ach = bucket_tot.get(k, 0) / n if n else 0
-                    print(f"Bucket {k}: {ach:.2f} (target {t:.2f})")
+                report_lineup_exposures(selected_players, self.player_dict, targets)
             else:
                 print(f"Warning: profile {self.profile} not found in config")
         else:

--- a/tests/test_selection_exposures.py
+++ b/tests/test_selection_exposures.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from selection_exposures import select_lineups
+from selection_exposures import select_lineups, report_lineup_exposures
 from stack_metrics import analyze_lineup
 
 
@@ -59,3 +59,11 @@ def test_selector_hits_targets():
         assert abs(mult_total[k] / n - tgt) <= 0.05
     for k, tgt in targets["bucket_mix_pct"].items():
         assert abs(bucket_total[k] / n - tgt) <= 0.02
+
+
+def test_report_lineup_exposures(capsys):
+    selected = select_lineups(lineups, player_dict, targets, 20)
+    report_lineup_exposures(selected, player_dict, targets)
+    out = capsys.readouterr().out
+    assert "Presence QB+WR: 0.50 (target 0.50)" in out
+    assert "Bucket QB+WR+OppWR: 0.50 (target 0.50)" in out


### PR DESCRIPTION
## Summary
- add `report_lineup_exposures` utility to summarize achieved vs targeted stack percentages
- use new report in optimizer and GPP simulator, selecting lineups to match profile targets
- test reporting output to ensure stacks are tracked

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3354e72c8833090bd2ea0b1534f17