### PR TITLE
Add downloadable result files

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -12,6 +12,12 @@
       <h2>{{ name }}</h2>
       {{ table|safe }}
     {% endfor %}
+    {% if lineup_url %}
+      <p><a href="{{ lineup_url }}">Download Lineups CSV</a></p>
+    {% endif %}
+    {% if stack_url %}
+      <p><a href="{{ stack_url }}">Download Stack Exposure CSV</a></p>
+    {% endif %}
     <a href="/">Back</a>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow downloading optimized or simulated lineup exports
- surface lineup and stack exposure download links on results page

## Testing
- `pytest`
- `python - <<'PY'
import sys, os
sys.path.append(os.path.join(os.getcwd(), 'src'))
from app import app, progress_data, run_optimizer, NFL_Optimizer
opto = NFL_Optimizer(site='dk', num_lineups=1, num_uniques=1)
run_optimizer(opto, 'dk', False)
client = app.test_client()
resp = client.get('/download/lineups')
print('lineups', resp.status_code, len(resp.data))
resp2 = client.get('/download/stacks')
print('stacks', resp2.status_code)
progress_data['output_path'] = None
resp3 = client.get('/download/lineups')
print('missing', resp3.status_code)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b3541ce3fc8330a701c60b16886356