### PR TITLE
Add downloadable result files

### DIFF
--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -2380,6 +2380,25 @@ class NFL_GPP_Simulator:
                 "Position": pos,
                 "Opponent": v.get("Opp"),
             }
+
+        report = report_lineup_exposures(
+            [x["Lineup"] for x in self.field_lineups.values()],
+            id_player_dict,
+            self.config,
+        )
+        self.stack_exposure_df = (
+            pd.concat(
+                [
+                    pd.Series(report.get("presence", {}), name="presence"),
+                    pd.Series(report.get("multiplicity", {}), name="multiplicity"),
+                    pd.Series(report.get("bucket", {}), name="bucket"),
+                ],
+                axis=1,
+            )
+            .fillna(0)
+            .rename_axis("Stack")
+            .reset_index()
+        )
         unique = {}
         for index, x in self.field_lineups.items():
             # if index == 0:

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -5,6 +5,7 @@ import datetime
 import pytz
 import timedelta
 import numpy as np
+import pandas as pd
 import pulp as plp
 import copy
 import itertools
@@ -950,6 +951,24 @@ class NFL_Optimizer:
         for lineup, fpts_used in self.lineups:
             sorted_lineup = self.sort_lineup(lineup)
             sorted_lineups.append((sorted_lineup, fpts_used))
+
+        # Aggregate stack metrics across all generated lineups
+        report = report_lineup_exposures(
+            [lu for lu, _ in sorted_lineups], self.player_dict, self.config
+        )
+        self.stack_exposure_df = (
+            pd.concat(
+                [
+                    pd.Series(report.get("presence", {}), name="presence"),
+                    pd.Series(report.get("multiplicity", {}), name="multiplicity"),
+                    pd.Series(report.get("bucket", {}), name="bucket"),
+                ],
+                axis=1,
+            )
+            .fillna(0)
+            .rename_axis("Stack")
+            .reset_index()
+        )
 
         team_stack_counts = {}
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -12,6 +12,12 @@
       <h2>{{ name }}</h2>
       {{ table|safe }}
     {% endfor %}
+    {% if lineup_url %}
+      <p><a href="{{ lineup_url }}">Download Lineups CSV</a></p>
+    {% endif %}
+    {% if stack_url %}
+      <p><a href="{{ stack_url }}">Download Stack Exposure CSV</a></p>
+    {% endif %}
     <a href="/">Back</a>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- allow downloading optimized or simulated lineup exports
- surface lineup and stack exposure download links on results page
- compute stack exposure CSVs during optimizer and simulator runs

## Testing
- `pytest`
- `python - <<'PY'
import sys, os
sys.path.append(os.path.join(os.getcwd(), 'src'))
from app import app, progress_data, run_optimizer, NFL_Optimizer
opto = NFL_Optimizer(site='dk', num_lineups=1, num_uniques=1)
run_optimizer(opto, 'dk', False)
print('progress', progress_data['output_path'], progress_data['stack_path'])
print('stack file exists', os.path.exists(progress_data['stack_path']))
client = app.test_client()
resp = client.get('/download/lineups')
print('lineups', resp.status_code, len(resp.data))
resp2 = client.get('/download/stacks')
print('stacks', resp2.status_code, len(resp2.data))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b3541ce3fc8330a701c60b16886356