### PR TITLE
Fix PGAgent action selection

### DIFF
--- a/src/dfs_rl/agents/pg_agent.py
+++ b/src/dfs_rl/agents/pg_agent.py
@@ -23,7 +23,16 @@ class PGAgent:
         self.last = None
 
     def act(self, mask):
-
+        x = torch.zeros(1, self.n)
+        logits = self.net(x).detach().numpy().flatten()
+        logits[mask == 0] = -1e9
+        probs = np.exp(logits - logits.max()); probs /= probs.sum()
+        a = int(np.random.choice(np.arange(self.n), p=probs))
+        self.last = (
+            torch.tensor(logits).unsqueeze(0),
+            a,
+            torch.tensor(mask, dtype=torch.float32).unsqueeze(0),
+        )
         return a
 
     def update(self, ret: float):


### PR DESCRIPTION
## Summary
- Implement missing action selection logic for policy gradient agent
- Store logits, action and mask for training update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b3b819024c83309ee50f0694ac8919