### PR TITLE
Include scoring details in backtester and arena

### DIFF
--- a/backtesting/backtester.py
+++ b/backtesting/backtester.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from typing import Dict, Optional
 
@@ -20,23 +21,27 @@ def backtest_week(week_dir: str, n_lineups_per_agent: int = 150) -> Dict[str, pd
     # If we have a contest file with lineup points, compare
     scored = None
     if bundle["contest_files"]:
-        import pandas as pd
         board = pd.read_csv(bundle["contest_files"][0])
         pts_col = _find_points_col(board)
         if pts_col is not None:
-            # percentile rank vs field by projections (or points if you wish to map)
             s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
             gen = gen.copy()
-            # naive: treat our 'proj' as comparable to points for ranking ballpark
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            gen["contest_rank"] = ranks
             gen["field_size"] = len(s)
-            gen["percentile"] = gen["sim_rank"] / gen["field_size"]
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                gen = gen.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                gen["amount_won"] = pd.to_numeric(gen["amount_won"], errors="coerce").fillna(0.0)
+            gen["percentile"] = gen["contest_rank"] / gen["field_size"]
             scored = gen
         else:
-            # fallback: rank just within our generated set
             gen = gen.copy()
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
-            gen["percentile"] = gen["sim_rank"] / len(gen)
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            gen["contest_rank"] = scores.rank(ascending=False, method="min")
+            gen["percentile"] = gen["contest_rank"] / len(gen)
             scored = gen
 
     return {"generated": gen, "scored": scored}

--- a/dfs_rl/arena.py
+++ b/dfs_rl/arena.py
@@ -37,6 +37,7 @@ def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150, train_pg:
                 "lineup_idx": i,
                 "salary": int(L["salary"].sum()),
                 "proj": float(L["projections_proj"].sum()),
+                "actual": float(L["projections_actpts"].sum()) if "projections_actpts" in L.columns else np.nan,
                 "players": "|".join(L["name"].tolist())
             })
     return pd.DataFrame(rows)

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from typing import Dict, Optional
 
@@ -20,23 +21,27 @@ def backtest_week(week_dir: str, n_lineups_per_agent: int = 150) -> Dict[str, pd
     # If we have a contest file with lineup points, compare
     scored = None
     if bundle["contest_files"]:
-        import pandas as pd
         board = pd.read_csv(bundle["contest_files"][0])
         pts_col = _find_points_col(board)
         if pts_col is not None:
-            # percentile rank vs field by projections (or points if you wish to map)
             s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
             gen = gen.copy()
-            # naive: treat our 'proj' as comparable to points for ranking ballpark
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            gen["contest_rank"] = ranks
             gen["field_size"] = len(s)
-            gen["percentile"] = gen["sim_rank"] / gen["field_size"]
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                gen = gen.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                gen["amount_won"] = pd.to_numeric(gen["amount_won"], errors="coerce").fillna(0.0)
+            gen["percentile"] = gen["contest_rank"] / gen["field_size"]
             scored = gen
         else:
-            # fallback: rank just within our generated set
             gen = gen.copy()
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
-            gen["percentile"] = gen["sim_rank"] / len(gen)
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            gen["contest_rank"] = scores.rank(ascending=False, method="min")
+            gen["percentile"] = gen["contest_rank"] / len(gen)
             scored = gen
 
     return {"generated": gen, "scored": scored}

--- a/src/dfs_rl/arena.py
+++ b/src/dfs_rl/arena.py
@@ -37,6 +37,7 @@ def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150, train_pg:
                 "lineup_idx": i,
                 "salary": int(L["salary"].sum()),
                 "proj": float(L["projections_proj"].sum()),
+                "actual": float(L["projections_actpts"].sum()) if "projections_actpts" in L.columns else np.nan,
                 "players": "|".join(L["name"].tolist())
             })
     return pd.DataFrame(rows)

--- a/src/pages/02_RL_Arena.py
+++ b/src/pages/02_RL_Arena.py
@@ -1,7 +1,9 @@
 import streamlit as st
 import pandas as pd
+import numpy as np
 from dfs_rl.utils.data import find_weeks, load_week_folder
 from dfs_rl.arena import run_tournament
+from backtesting.backtester import _find_points_col
 
 st.set_page_config(page_title="RL Arena", layout="wide")
 
@@ -23,5 +25,19 @@ if st.button("Run Arena"):
     with st.spinner("Generating lineups..."):
         df = run_tournament(bundle["projections"], n_lineups_per_agent=n, train_pg=True)
     st.success("Done")
+    if bundle["contest_files"]:
+        board = pd.read_csv(bundle["contest_files"][0])
+        pts_col = _find_points_col(board)
+        if pts_col is not None:
+            s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
+            scores = df["actual"] if "actual" in df.columns else df["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            df["contest_rank"] = ranks
+            df["field_size"] = len(s)
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                df = df.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                df["amount_won"] = pd.to_numeric(df["amount_won"], errors="coerce").fillna(0.0)
     st.dataframe(df.head(50), use_container_width=True)
     st.download_button("Download all lineups (CSV)", df.to_csv(index=False).encode(), file_name="arena_lineups.csv")

--- a/src/pages/03_Backtester.py
+++ b/src/pages/03_Backtester.py
@@ -22,5 +22,5 @@ if st.button("Run Backtest"):
     st.subheader("Generated lineups")
     st.dataframe(out["generated"].head(50), use_container_width=True)
     if out["scored"] is not None:
-        st.subheader("Scored vs contest (percentile & sim_rank by projections)")
+        st.subheader("Scored vs contest (rank & winnings)")
         st.dataframe(out["scored"].head(50), use_container_width=True)


### PR DESCRIPTION
## Summary
- Add actual scoring for generated lineups in RL tournament logic
- Score backtest and arena lineups against contest fields with ranks and winnings
- Update Streamlit pages to display player names, actual points, contest ranks, and payouts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3bdfdbcec83309f15e7cbef6f2237