### PR TITLE
Include scoring details in backtester and arena

### DIFF
--- a/backtesting/backtester.py
+++ b/backtesting/backtester.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from typing import Dict, Optional
 
@@ -20,23 +21,27 @@ def backtest_week(week_dir: str, n_lineups_per_agent: int = 150) -> Dict[str, pd
     # If we have a contest file with lineup points, compare
     scored = None
     if bundle["contest_files"]:
-        import pandas as pd
         board = pd.read_csv(bundle["contest_files"][0])
         pts_col = _find_points_col(board)
         if pts_col is not None:
-            # percentile rank vs field by projections (or points if you wish to map)
             s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
             gen = gen.copy()
-            # naive: treat our 'proj' as comparable to points for ranking ballpark
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            gen["contest_rank"] = ranks
             gen["field_size"] = len(s)
-            gen["percentile"] = gen["sim_rank"] / gen["field_size"]
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                gen = gen.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                gen["amount_won"] = pd.to_numeric(gen["amount_won"], errors="coerce").fillna(0.0)
+            gen["percentile"] = gen["contest_rank"] / gen["field_size"]
             scored = gen
         else:
-            # fallback: rank just within our generated set
             gen = gen.copy()
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
-            gen["percentile"] = gen["sim_rank"] / len(gen)
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            gen["contest_rank"] = scores.rank(ascending=False, method="min")
+            gen["percentile"] = gen["contest_rank"] / len(gen)
             scored = gen
 
     return {"generated": gen, "scored": scored}

--- a/dfs_rl/arena.py
+++ b/dfs_rl/arena.py
@@ -1,10 +1,27 @@
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import numpy as np
 import pandas as pd
 
 from dfs_rl.envs.dk_nfl_env import DKNFLEnv
 from dfs_rl.agents.random_agent import RandomAgent
 from dfs_rl.agents.pg_agent import PGAgent
+
+POINTS_COLS = [
+    "projections_actpts",
+    "score",
+    "dk_points",
+    "lineup_points",
+    "points",
+    "FPTS",
+    "total_points",
+]
+
+
+def _find_points_col(df: pd.DataFrame) -> Optional[str]:
+    for c in df.columns:
+        if c.lower() in [x.lower() for x in POINTS_COLS]:
+            return c
+    return None
 
 def _run_agent(env: DKNFLEnv, agent, train: bool) -> Tuple[list,int,float]:
     obs, info = env.reset()
@@ -25,18 +42,24 @@ def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150, train_pg:
     n = len(pool)
     agents = {
         "random": RandomAgent(seed=1),
-        "pg": PGAgent(n_players=n, seed=2)
+        "pg": PGAgent(n_players=n, seed=2),
     }
+
+    pts_col = _find_points_col(pool)
+
     rows = []
     for name, agent in agents.items():
         for i in range(n_lineups_per_agent):
-            idxs, steps, reward = _run_agent(env, agent, train=(train_pg and name=="pg"))
+            idxs, steps, reward = _run_agent(env, agent, train=(train_pg and name == "pg"))
             L = pool.iloc[idxs].copy()
-            rows.append({
-                "agent": name,
-                "lineup_idx": i,
-                "salary": int(L["salary"].sum()),
-                "proj": float(L["projections_proj"].sum()),
-                "players": "|".join(L["name"].tolist())
-            })
+            rows.append(
+                {
+                    "agent": name,
+                    "lineup_idx": i,
+                    "salary": int(L["salary"].sum()),
+                    "proj": float(L["projections_proj"].sum()),
+                    "actual": float(L[pts_col].sum()) if pts_col else np.nan,
+                    "players": "|".join(L["name"].tolist()),
+                }
+            )
     return pd.DataFrame(rows)

--- a/dfs_rl/utils/data.py
+++ b/dfs_rl/utils/data.py
@@ -8,7 +8,7 @@ PROJ_COLS = ["name","pos","team","opp","salary","projections_proj"]
 def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     """
     Load projections, players_ids, and contest CSVs for a given historical week.
-    - projections.csv: copy of *_Dadjusted.csv (must include name,pos,team,opp,salary,projections_proj)
+    - projections.csv: copy of *adjusted.csv from FantasyLabs (must include name,pos,team,opp,salary,projections_proj)
     - players_ids.csv: copy of YYYY-MM-DD.csv (must include displayname,draftableid)
     - contests/*.csv: Aggregated_Lineup_Stats_*.csv (leaderboard)
     """
@@ -18,8 +18,9 @@ def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     # projections
     proj_fp = os.path.join(week_dir, "projections.csv")
     if not os.path.exists(proj_fp):
-        # fallback: auto-pick a *_Dadjusted.csv if user drops it directly
-        cand = glob.glob(os.path.join(week_dir, "*_Dadjusted.csv"))
+        # fallback: auto-pick any *adjusted.csv if user drops it directly
+        cand = [p for p in glob.glob(os.path.join(week_dir, "*adjusted.csv"))
+                if "Aggregated_Lineup_Stats" not in os.path.basename(p)]
         if cand:
             proj_fp = cand[0]
     proj = pd.read_csv(proj_fp)
@@ -34,9 +35,13 @@ def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     # players ids
     pid_fp = os.path.join(week_dir, "players_ids.csv")
     if not os.path.exists(pid_fp):
+        # allow singular form
+        pid_fp = os.path.join(week_dir, "player_ids.csv")
+    if not os.path.exists(pid_fp):
         # fallback: try a dated csv in the folder (like '2019-09-22.csv')
         cand = [p for p in glob.glob(os.path.join(week_dir, "*.csv"))
-                if os.path.basename(p).startswith("201") and "Aggregated_Lineup_Stats" not in os.path.basename(p)]
+                if os.path.basename(p).startswith("201") and "Aggregated_Lineup_Stats" not in os.path.basename(p)
+                   and "adjusted" not in os.path.basename(p).lower()]
         if cand:
             pid_fp = cand[0]
     pids = pd.read_csv(pid_fp) if os.path.exists(pid_fp) else pd.DataFrame()

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 from typing import Dict, Optional
 
@@ -20,23 +21,27 @@ def backtest_week(week_dir: str, n_lineups_per_agent: int = 150) -> Dict[str, pd
     # If we have a contest file with lineup points, compare
     scored = None
     if bundle["contest_files"]:
-        import pandas as pd
         board = pd.read_csv(bundle["contest_files"][0])
         pts_col = _find_points_col(board)
         if pts_col is not None:
-            # percentile rank vs field by projections (or points if you wish to map)
             s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
             gen = gen.copy()
-            # naive: treat our 'proj' as comparable to points for ranking ballpark
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            gen["contest_rank"] = ranks
             gen["field_size"] = len(s)
-            gen["percentile"] = gen["sim_rank"] / gen["field_size"]
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                gen = gen.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                gen["amount_won"] = pd.to_numeric(gen["amount_won"], errors="coerce").fillna(0.0)
+            gen["percentile"] = gen["contest_rank"] / gen["field_size"]
             scored = gen
         else:
-            # fallback: rank just within our generated set
             gen = gen.copy()
-            gen["sim_rank"] = gen["proj"].rank(ascending=False, method="min")
-            gen["percentile"] = gen["sim_rank"] / len(gen)
+            scores = gen["actual"] if "actual" in gen.columns else gen["proj"]
+            gen["contest_rank"] = scores.rank(ascending=False, method="min")
+            gen["percentile"] = gen["contest_rank"] / len(gen)
             scored = gen
 
     return {"generated": gen, "scored": scored}

--- a/src/dfs_rl/arena.py
+++ b/src/dfs_rl/arena.py
@@ -1,10 +1,27 @@
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import numpy as np
 import pandas as pd
 
 from dfs_rl.envs.dk_nfl_env import DKNFLEnv
 from dfs_rl.agents.random_agent import RandomAgent
 from dfs_rl.agents.pg_agent import PGAgent
+
+POINTS_COLS = [
+    "projections_actpts",
+    "score",
+    "dk_points",
+    "lineup_points",
+    "points",
+    "FPTS",
+    "total_points",
+]
+
+
+def _find_points_col(df: pd.DataFrame) -> Optional[str]:
+    for c in df.columns:
+        if c.lower() in [x.lower() for x in POINTS_COLS]:
+            return c
+    return None
 
 def _run_agent(env: DKNFLEnv, agent, train: bool) -> Tuple[list,int,float]:
     obs, info = env.reset()
@@ -25,18 +42,24 @@ def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150, train_pg:
     n = len(pool)
     agents = {
         "random": RandomAgent(seed=1),
-        "pg": PGAgent(n_players=n, seed=2)
+        "pg": PGAgent(n_players=n, seed=2),
     }
+
+    pts_col = _find_points_col(pool)
+
     rows = []
     for name, agent in agents.items():
         for i in range(n_lineups_per_agent):
-            idxs, steps, reward = _run_agent(env, agent, train=(train_pg and name=="pg"))
+            idxs, steps, reward = _run_agent(env, agent, train=(train_pg and name == "pg"))
             L = pool.iloc[idxs].copy()
-            rows.append({
-                "agent": name,
-                "lineup_idx": i,
-                "salary": int(L["salary"].sum()),
-                "proj": float(L["projections_proj"].sum()),
-                "players": "|".join(L["name"].tolist())
-            })
+            rows.append(
+                {
+                    "agent": name,
+                    "lineup_idx": i,
+                    "salary": int(L["salary"].sum()),
+                    "proj": float(L["projections_proj"].sum()),
+                    "actual": float(L[pts_col].sum()) if pts_col else np.nan,
+                    "players": "|".join(L["name"].tolist()),
+                }
+            )
     return pd.DataFrame(rows)

--- a/src/dfs_rl/utils/data.py
+++ b/src/dfs_rl/utils/data.py
@@ -8,7 +8,7 @@ PROJ_COLS = ["name","pos","team","opp","salary","projections_proj"]
 def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     """
     Load projections, players_ids, and contest CSVs for a given historical week.
-    - projections.csv: copy of *_Dadjusted.csv (must include name,pos,team,opp,salary,projections_proj)
+    - projections.csv: copy of *adjusted.csv from FantasyLabs (must include name,pos,team,opp,salary,projections_proj)
     - players_ids.csv: copy of YYYY-MM-DD.csv (must include displayname,draftableid)
     - contests/*.csv: Aggregated_Lineup_Stats_*.csv (leaderboard)
     """
@@ -18,8 +18,9 @@ def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     # projections
     proj_fp = os.path.join(week_dir, "projections.csv")
     if not os.path.exists(proj_fp):
-        # fallback: auto-pick a *_Dadjusted.csv if user drops it directly
-        cand = glob.glob(os.path.join(week_dir, "*_Dadjusted.csv"))
+        # fallback: auto-pick any *adjusted.csv if user drops it directly
+        cand = [p for p in glob.glob(os.path.join(week_dir, "*adjusted.csv"))
+                if "Aggregated_Lineup_Stats" not in os.path.basename(p)]
         if cand:
             proj_fp = cand[0]
     proj = pd.read_csv(proj_fp)
@@ -34,9 +35,13 @@ def load_week_folder(week_dir: str) -> Dict[str, pd.DataFrame]:
     # players ids
     pid_fp = os.path.join(week_dir, "players_ids.csv")
     if not os.path.exists(pid_fp):
+        # allow singular form
+        pid_fp = os.path.join(week_dir, "player_ids.csv")
+    if not os.path.exists(pid_fp):
         # fallback: try a dated csv in the folder (like '2019-09-22.csv')
         cand = [p for p in glob.glob(os.path.join(week_dir, "*.csv"))
-                if os.path.basename(p).startswith("201") and "Aggregated_Lineup_Stats" not in os.path.basename(p)]
+                if os.path.basename(p).startswith("201") and "Aggregated_Lineup_Stats" not in os.path.basename(p)
+                   and "adjusted" not in os.path.basename(p).lower()]
         if cand:
             pid_fp = cand[0]
     pids = pd.read_csv(pid_fp) if os.path.exists(pid_fp) else pd.DataFrame()

--- a/src/pages/02_RL_Arena.py
+++ b/src/pages/02_RL_Arena.py
@@ -1,7 +1,9 @@
 import streamlit as st
 import pandas as pd
+import numpy as np
 from dfs_rl.utils.data import find_weeks, load_week_folder
 from dfs_rl.arena import run_tournament
+from backtesting.backtester import _find_points_col
 
 st.set_page_config(page_title="RL Arena", layout="wide")
 
@@ -23,5 +25,19 @@ if st.button("Run Arena"):
     with st.spinner("Generating lineups..."):
         df = run_tournament(bundle["projections"], n_lineups_per_agent=n, train_pg=True)
     st.success("Done")
+    if bundle["contest_files"]:
+        board = pd.read_csv(bundle["contest_files"][0])
+        pts_col = _find_points_col(board)
+        if pts_col is not None:
+            s = pd.to_numeric(board[pts_col], errors="coerce").dropna().sort_values(ascending=False).reset_index(drop=True)
+            scores = df["actual"] if "actual" in df.columns else df["proj"]
+            arr = scores.fillna(0).to_numpy()
+            ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
+            df["contest_rank"] = ranks
+            df["field_size"] = len(s)
+            if "amount_won" in board.columns:
+                payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
+                df = df.merge(payouts, left_on="contest_rank", right_on="rank", how="left").drop(columns=["rank"])
+                df["amount_won"] = pd.to_numeric(df["amount_won"], errors="coerce").fillna(0.0)
     st.dataframe(df.head(50), use_container_width=True)
     st.download_button("Download all lineups (CSV)", df.to_csv(index=False).encode(), file_name="arena_lineups.csv")

--- a/src/pages/03_Backtester.py
+++ b/src/pages/03_Backtester.py
@@ -22,5 +22,5 @@ if st.button("Run Backtest"):
     st.subheader("Generated lineups")
     st.dataframe(out["generated"].head(50), use_container_width=True)
     if out["scored"] is not None:
-        st.subheader("Scored vs contest (percentile & sim_rank by projections)")
+        st.subheader("Scored vs contest (rank & winnings)")
         st.dataframe(out["scored"].head(50), use_container_width=True)


### PR DESCRIPTION
## Summary
- Detect actual scoring columns when running tournaments to populate lineup points
- Keep player names and actual totals for generated lineups in arena outputs
- Support adjusted projection and player ID filenames when loading historical weeks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3bdfdbcec83309f15e7cbef6f2237