### PR TITLE
Generate RL tournament lineups and fix backtester scoring

### DIFF
--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -23,22 +23,28 @@ def backtest_week(week_dir: str, n_lineups_per_agent: int = 150) -> Dict[str, pd
     if bundle["contest_files"]:
         board = pd.read_csv(bundle["contest_files"][0])
         pts_col = _find_points_col(board)
-        if pts_col is not None:
-
+        if pts_col and pts_col in gen.columns:
+            scores = gen[pts_col]
+            s = board.sort_values(pts_col, ascending=False)[pts_col]
             arr = scores.fillna(0).to_numpy()
             ranks = np.searchsorted(-s.to_numpy(), -arr, side="left") + 1
             gen["contest_rank"] = ranks
             gen["field_size"] = len(s)
             if "amount_won" in board.columns:
                 payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
-
+                gen = gen.merge(payouts, left_on="contest_rank", right_on="rank", how="left")
             gen["percentile"] = gen["contest_rank"] / gen["field_size"]
             scored = gen
         else:
             gen = gen.copy()
-
-            gen["contest_rank"] = scores.rank(ascending=False, method="min")
-            gen["percentile"] = gen["contest_rank"] / len(gen)
+            pts_col_gen = _find_points_col(gen)
+            if pts_col_gen:
+                scores = gen[pts_col_gen]
+                gen["contest_rank"] = scores.rank(ascending=False, method="min")
+                gen["percentile"] = gen["contest_rank"] / len(gen)
+            else:
+                gen["contest_rank"] = np.nan
+                gen["percentile"] = np.nan
             scored = gen
 
     return {"generated": gen, "scored": scored}

--- a/src/pages/02_RL_Arena.py
+++ b/src/pages/02_RL_Arena.py
@@ -39,7 +39,7 @@ if st.button("Run Arena"):
                 payouts = board[["rank", "amount_won"]].drop_duplicates("rank")
                 df = df.merge(payouts, left_on="contest_rank", right_on="rank", how="left")
 
-    st.dataframe(df.head(50), use_container_width=True)
+    st.dataframe(df.head(50), width="stretch")
     st.download_button(
         "Download all lineups (CSV)",
         df.to_csv(index=False).encode(),

--- a/src/pages/03_Backtester.py
+++ b/src/pages/03_Backtester.py
@@ -20,7 +20,7 @@ if st.button("Run Backtest"):
         out = backtest_week(week_dir, n_lineups_per_agent=n)
     st.success("Done")
     st.subheader("Generated lineups")
-    st.dataframe(out["generated"].head(50), use_container_width=True)
+    st.dataframe(out["generated"].head(50), width="stretch")
     if out["scored"] is not None:
         st.subheader("Scored vs contest (rank & winnings)")
-        st.dataframe(out["scored"].head(50), use_container_width=True)
+        st.dataframe(out["scored"].head(50), width="stretch")


### PR DESCRIPTION
## Summary
- Populate RL tournament with agent lineups including positions, salary, projections, and scores so Arena and backtester produce results
- Define and use `score` when backtesting to compute contest ranks and percentiles
- Replace deprecated Streamlit `use_container_width` with `width='stretch'`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3cec84768833082345e8859eac95f