### PR TITLE
Add salary floor penalty to DK NFL environment

### DIFF
--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -16,6 +16,7 @@ class DKNFLEnv(gym.Env if gym else object):
     Lineup-construction environment with action masking.
     - player_pool must include: name,pos,team,opp,salary,projections_proj
     - Reward: sum of projections (or actuals if later attached)
+      with a penalty for spending less than $49,300 of the cap
     """
     metadata = {"render_modes": []}
 
@@ -74,6 +75,9 @@ class DKNFLEnv(gym.Env if gym else object):
         done = self.slot_idx >= 9
         if done:
             reward = float(self.pool.loc[self.picks, "projections_proj"].sum())
+            total_salary = DK_CAP - self.cap
+            if total_salary < 49300:
+                reward -= (49300 - total_salary)
             return np.array([1.0], dtype=np.float32), reward, True, False, {"lineup_indices": self.picks}
         else:
             return np.array([0.0], dtype=np.float32), 0.0, False, False, {"action_mask": self._mask()}


### PR DESCRIPTION
## Summary
- Document salary floor penalty for DraftKings NFL environment
- Deduct reward for lineups spending under $49,300 in DK cap

## Testing
- `pytest`
- `python3 - <<'PY'
import pandas as pd
import numpy as np
from dfs_rl.envs.dk_nfl_env import DKNFLEnv
players=[{"name":"QB1","pos":"QB","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"RB1","pos":"RB","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"RB2","pos":"RB","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"WR1","pos":"WR","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"WR2","pos":"WR","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"WR3","pos":"WR","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"TE1","pos":"TE","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"RB3","pos":"RB","team":"A","opp":"B","salary":5000,"projections_proj":10},{"name":"DST1","pos":"DST","team":"A","opp":"B","salary":3000,"projections_proj":10}]
df=pd.DataFrame(players)
env=DKNFLEnv(df)
obs,info=env.reset()
for i in range(9):
    obs,reward,terminated,truncated,info=env.step(i)
    if terminated:
        print('Total reward:',reward)
        print('Lineup indices:',info['lineup_indices'])
        break
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4fe7ea7dc83309c03d210f94ab76a