### PR TITLE
Add salary floor penalty to DK NFL environment

### DIFF
--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -16,6 +16,8 @@ class DKNFLEnv(gym.Env if gym else object):
     Lineup-construction environment with action masking.
     - player_pool must include: name,pos,team,opp,salary,projections_proj
     - Reward: sum of projections (or actuals if later attached)
+      with a penalty for spending less than $49,300 of the cap
+    - Mask drops actions that make the $49,300 floor unreachable
     """
     metadata = {"render_modes": []}
 
@@ -39,6 +41,24 @@ class DKNFLEnv(gym.Env if gym else object):
     def _needed_pos(self, slot_idx: int) -> str:
         return "FLEX" if SLOTS[slot_idx] == "FLEX" else SLOTS[slot_idx]
 
+    def _max_possible_salary(self, picks: list) -> int:
+        used = set(picks)
+        total = int(self.pool.loc[picks, "salary"].sum()) if picks else 0
+        for slot in range(len(picks), 9):
+            need = SLOTS[slot]
+            if need == "FLEX":
+                candidates = []
+                for p in ("RB", "WR", "TE"):
+                    candidates += [j for j in self.idx_by_pos[p] if j not in used]
+            else:
+                candidates = [j for j in self.idx_by_pos[need] if j not in used]
+            if not candidates:
+                return total
+            j = max(candidates, key=lambda x: int(self.pool.loc[x, "salary"]))
+            total += int(self.pool.loc[j, "salary"])
+            used.add(j)
+        return total
+
     def _mask(self) -> np.ndarray:
         n = len(self.pool)
         mask = np.zeros(n, dtype=np.int8)
@@ -51,10 +71,13 @@ class DKNFLEnv(gym.Env if gym else object):
             allowed.update(self.idx_by_pos[need])
         remain_slots = 9 - (len(self.picks) + 1)
         for i in allowed:
-            if i in self.picks: continue
-            sal = int(self.pool.loc[i,"salary"])
-            # naive min-salary buffer (2k per remaining slot)
-            if sal <= self.cap - 2000*max(0, remain_slots):
+            if i in self.picks:
+                continue
+            sal = int(self.pool.loc[i, "salary"])
+            # ensure we can still afford remaining slots
+            if sal > self.cap - 2000 * max(0, remain_slots):
+                continue
+            if self._max_possible_salary(self.picks + [i]) >= 49300:
                 mask[i] = 1
         return mask
 
@@ -74,6 +97,9 @@ class DKNFLEnv(gym.Env if gym else object):
         done = self.slot_idx >= 9
         if done:
             reward = float(self.pool.loc[self.picks, "projections_proj"].sum())
+            total_salary = DK_CAP - self.cap
+            if total_salary < 49300:
+                reward -= (49300 - total_salary)
             return np.array([1.0], dtype=np.float32), reward, True, False, {"lineup_indices": self.picks}
         else:
             return np.array([0.0], dtype=np.float32), 0.0, False, False, {"action_mask": self._mask()}


### PR DESCRIPTION
## Summary
- Document salary floor penalty for DraftKings NFL environment
- Deduct reward for lineups spending under $49,300 in DK cap
- Mask out actions that would make the $49,300 floor unreachable

## Testing
- `pytest`
- `python - <<'PY'
import sys, pandas as pd, numpy as np
sys.path.append('.')
sys.path.append('src')
from dfs_rl.envs.dk_nfl_env import DKNFLEnv
from dfs_rl.agents.random_agent import RandomAgent
pool = pd.read_csv('dk_data/projections.csv')
agent = RandomAgent(seed=1)
env = DKNFLEnv(pool)
obs, info = env.reset()
steps=0
while True:
    a = agent.act(info['action_mask'])
    obs, reward, done, trunc, info = env.step(a)
    steps += 1
    if done or steps>20:
        if done:
            total_salary = pool.loc[env.picks, 'salary'].sum()
            print('done', total_salary, 'reward', reward)
        else:
            print('failed, steps', steps)
        break
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4fe7ea7dc83309c03d210f94ab76a