### PR TITLE
Integrate stack-aware reward shaping into RL arena

### DIFF
--- a/config.json
+++ b/config.json
@@ -65,6 +65,22 @@
     }
   },
 
+  "rl_reward": {
+    "force_active": true,
+    "epsilon_greedy": 0.05,
+    "weights": {
+      "proj": 1.0,
+      "salary_util": 0.4,
+      "qb_wr_bonus": 8.0,
+      "qb_te_bonus": 4.0,
+      "bringback_bonus": 3.0,
+      "double_te_penalty": -6.0,
+      "dst_conflict_penalty": -5.0,
+      "flex_wr_bonus": 2.0,
+      "flex_te_penalty": -3.0
+    }
+  },
+
   "profiles": {
     "top10_consistency": {
       "presence_targets_pct": {

--- a/src/dfs_rl/agents/greedy_agent.py
+++ b/src/dfs_rl/agents/greedy_agent.py
@@ -1,14 +1,25 @@
 import numpy as np
+from dfs.rl_reward import compute_partial_reward
 
 class GreedyAgent:
-    """Agent that always selects the highest-projected valid player."""
-    def __init__(self, projections: np.ndarray):
-        # flatten to 1D numpy array for indexing
-        self.proj = np.asarray(projections, dtype=float)
+    """Greedy agent that selects the action yielding the largest reward delta."""
+
+    def __init__(self, env, epsilon: float = 0.05):
+        self.env = env
+        self.eps = float(epsilon)
 
     def act(self, mask):
-        idx = np.where(mask == 1)[0]
-        if len(idx) == 0:
+        legal = np.where(mask == 1)[0]
+        if len(legal) == 0:
             return 0
-        best = idx[np.argmax(self.proj[idx])]
-        return int(best)
+        if np.random.rand() < self.eps:
+            return int(np.random.choice(legal))
+        baseline = compute_partial_reward(self.env.cur_row, self.env.rl_reward_cfg)
+        best_a, best_s = legal[0], -1e9
+        for a in legal:
+            self.env._push_preview(int(a))
+            s = compute_partial_reward(self.env.cur_row, self.env.rl_reward_cfg) - baseline
+            self.env._pop_preview()
+            if s > best_s:
+                best_s, best_a = s, int(a)
+        return int(best_a)

--- a/src/dfs_rl/agents/pg_agent.py
+++ b/src/dfs_rl/agents/pg_agent.py
@@ -1,4 +1,6 @@
-import torch, torch.nn as nn, torch.optim as optim
+import torch
+import torch.nn as nn
+import torch.optim as optim
 
 class TinyPolicy(nn.Module):
     def __init__(self, n_players: int, hidden: int = 128):
@@ -6,34 +8,40 @@ class TinyPolicy(nn.Module):
         self.net = nn.Sequential(
             nn.Linear(n_players, hidden),
             nn.ReLU(),
-            nn.Linear(hidden, n_players)
+            nn.Linear(hidden, n_players),
         )
 
     def forward(self, x):
         return self.net(x)
 
 class PGAgent:
-    """Tiny REINFORCE policy that learns a distribution over players; mask invalid actions."""
+    """REINFORCE policy that learns from shaped rewards."""
+
     def __init__(self, n_players: int, lr: float = 1e-3, seed: int = 42):
         torch.manual_seed(seed)
         self.n = n_players
-        self.net = TinyPolicy(n_players)
-        self.opt = optim.Adam(self.net.parameters(), lr=lr)
-        self.last = None
+        self.policy = TinyPolicy(n_players)
+        self.opt = optim.Adam(self.policy.parameters(), lr=lr)
 
-    def act(self, mask):
+    def sample(self, mask):
         x = torch.zeros(1, self.n)
-        logits = self.net(x)
+        logits = self.policy(x)
         mask_t = torch.tensor(mask, dtype=torch.bool).unsqueeze(0)
         masked = logits.masked_fill(~mask_t, -1e9)
-        probs = torch.softmax(masked, dim=-1)
-        a = torch.distributions.Categorical(probs).sample().item()
-        self.last = (logits, a, mask_t)
-        return a
+        dist = torch.distributions.Categorical(logits=masked)
+        a = dist.sample()
+        logp = dist.log_prob(a)
+        return int(a.item()), logp
 
-    def update(self, ret: float):
-        logits, a, m = self.last
-        masked = logits.masked_fill(~m, -1e9)
-        logp = torch.log_softmax(masked, dim=-1)[0, a]
-        loss = -logp * torch.tensor(ret, dtype=torch.float32)
-        self.opt.zero_grad(); loss.backward(); self.opt.step()
+    def update(self, states, actions, rewards):
+        returns = []
+        g = 0.0
+        for r in reversed(rewards):
+            g = float(r) + g
+            returns.insert(0, g)
+        loss = 0.0
+        for (_, logp), R in zip(actions, returns):
+            loss = loss + (-logp * torch.tensor(R, dtype=torch.float32))
+        self.opt.zero_grad()
+        loss.backward()
+        self.opt.step()

--- a/src/dfs_rl/arena.py
+++ b/src/dfs_rl/arena.py
@@ -9,53 +9,27 @@ from dfs_rl.envs.dk_nfl_env import DKNFLEnv
 from dfs_rl.agents.random_agent import RandomAgent
 from dfs_rl.agents.pg_agent import PGAgent
 from dfs_rl.agents.greedy_agent import GreedyAgent
-from dfs.constraints import (
-    Player,
-    Lineup,
-    validate_lineup,
-    repair_to_min_salary,
-    sanitize_salary,
-    DEFAULT_SALARY_CAP,
-    DEFAULT_MIN_SPEND_PCT,
-)
-from dfs.stacks import (
-    compute_presence_and_counts,
-    classify_bucket,
-    compute_features,
-)
-from dfs.rl_reward import compute_reward
+from dfs.constraints import sanitize_salary, DEFAULT_MIN_SPEND_PCT, DEFAULT_SALARY_CAP
+from dfs.rl_reward import compute_reward_components
 from utils import get_config_path
 
-POINTS_COLS = [
-    "projections_actpts",
-    "score",
-    "dk_points",
-    "lineup_points",
-    "points",
-    "FPTS",
-    "total_points",
-]
-
-
-def _find_points_col(df: pd.DataFrame) -> Optional[str]:
-    for c in df.columns:
-        if c.lower() in [x.lower() for x in POINTS_COLS]:
-            return c
-    return None
-
-def _run_agent(env: DKNFLEnv, agent, train: bool) -> Tuple[list, int, float]:
+def _run_agent(env: DKNFLEnv, agent, train: bool) -> Tuple[list, int, float, Dict[str, Any]]:
+    states, actions, rewards = [], [], []
     obs, info = env.reset()
-    total = 0.0
-    steps = 0
-    while True:
-        a = agent.act(info["action_mask"])
-        obs, r, done, trunc, info = env.step(a)
-        total += float(r)
-        steps += 1
-        if done or steps > 20:
-            if train and hasattr(agent, "update"):
-                agent.update(total)
-            return info.get("lineup_indices", []), steps, total
+    done = False
+    while not done:
+        mask = info["action_mask"]
+        if hasattr(agent, "sample"):
+            a, logp = agent.sample(mask)
+            actions.append((a, logp))
+        else:
+            a = agent.act(mask)
+        obs, r, done, _, info = env.step(a)
+        rewards.append(r)
+        states.append(obs)
+    if train and hasattr(agent, "update"):
+        agent.update(states, actions, rewards)
+    return info.get("lineup_indices", []), len(rewards), float(sum(rewards)), info
 
 
 def run_tournament(
@@ -63,27 +37,15 @@ def run_tournament(
     n_lineups_per_agent: int = 150,
     train_pg: bool = True,
     min_salary_pct: float | None = None,
+    seed: int | None = None,
 ) -> pd.DataFrame:
     if min_salary_pct is None:
         min_salary_pct = float(os.getenv("MIN_SALARY_PCT", DEFAULT_MIN_SPEND_PCT))
+    if seed is not None:
+        np.random.seed(int(seed))
 
     pool = pool.copy()
     pool["salary"] = pool["salary"].apply(sanitize_salary)
-
-    players: List[Player] = []
-    pool_by_pos = {"QB": [], "RB": [], "WR": [], "TE": [], "DST": []}
-    for idx, row in pool.iterrows():
-        p = Player(
-            id=str(idx),
-            name=row["name"],
-            pos=row["pos"],
-            team=row.get("team"),
-            opp=row.get("opp"),
-            salary=int(row["salary"]),
-            proj=float(row["projections_proj"]),
-        )
-        players.append(p)
-        pool_by_pos[p.pos].append(p)
 
     cfg: Dict[str,Any] = {}
     try:
@@ -91,94 +53,46 @@ def run_tournament(
             cfg = json.load(f)
     except Exception:
         cfg = {}
-    rl_reward_cfg = (cfg.get("rl") or {}).get("reward", {})
+    rl_reward_cfg = cfg.get("rl_reward", {})
+
+    if rl_reward_cfg.get("force_active"):
+        w_flip = {k: -v for k, v in (rl_reward_cfg.get("weights", {})).items()}
+        cfg_flip = {**rl_reward_cfg, "weights": w_flip}
+        env_a = DKNFLEnv(pool, min_salary_pct=min_salary_pct, rl_reward_cfg=rl_reward_cfg)
+        env_b = DKNFLEnv(pool, min_salary_pct=min_salary_pct, rl_reward_cfg=cfg_flip)
+        ga = GreedyAgent(env_a, epsilon=0.0)
+        gb = GreedyAgent(env_b, epsilon=0.0)
+        idx_a, _, _, _ = _run_agent(env_a, ga, train=False)
+        idx_b, _, _, _ = _run_agent(env_b, gb, train=False)
+        if idx_a == idx_b:
+            raise RuntimeError("RL reward appears inactive; flipping weights produced same lineup")
 
     env = DKNFLEnv(pool, min_salary_pct=min_salary_pct, rl_reward_cfg=rl_reward_cfg)
     n = len(pool)
+    base_seed = int(seed) if seed is not None else 0
     agents = {
-        "random": RandomAgent(pool["salary"].to_numpy(), seed=1),
-        "pg": PGAgent(n_players=n, seed=2),
-        "greedy": GreedyAgent(pool["projections_proj"].to_numpy()),
+        "random": RandomAgent(pool["salary"].to_numpy(), seed=base_seed + 1),
+        "pg": PGAgent(n_players=n, seed=base_seed + 2),
+        "greedy": GreedyAgent(env, epsilon=rl_reward_cfg.get("epsilon_greedy", 0.05)),
     }
-
-    pts_col = _find_points_col(pool)
 
     rows = []
     slot_cols = ["QB", "RB1", "RB2", "WR1", "WR2", "WR3", "TE", "FLEX", "DST"]
 
     for name, agent in agents.items():
         for i in range(n_lineups_per_agent):
-            idxs, steps, reward = _run_agent(
+            idxs, steps, reward, info = _run_agent(
                 env, agent, train=(train_pg and name == "pg")
             )
             if len(idxs) != len(slot_cols):
                 continue
 
-            lineup = Lineup()
-            for slot, idx in zip(slot_cols, idxs):
-                setattr(lineup, slot, players[idx])
-
-            if not validate_lineup(
-                lineup, cap=DEFAULT_SALARY_CAP, min_pct=min_salary_pct
-            ):
-                before = lineup.salary()
-                lineup = repair_to_min_salary(
-                    lineup, pool_by_pos, cap=DEFAULT_SALARY_CAP, min_pct=min_salary_pct
-                )
-                if lineup.salary() != before:
-                    print(f"REPAIRED from ${before} to ${lineup.salary()}")
-
-            if not validate_lineup(
-                lineup, cap=DEFAULT_SALARY_CAP, min_pct=min_salary_pct
-            ):
-                print(
-                    f"Discarding invalid lineup from {name} with salary {lineup.salary()}"
-                )
+            row = info.copy()
+            if float(row.get("salary", 0.0)) < DEFAULT_SALARY_CAP * min_salary_pct:
                 continue
-
-            row: Dict[str,Any] = {"agent": name, "iteration": i, "salary": lineup.salary()}
-            for slot in slot_cols:
-                p = getattr(lineup, slot)
-                row[slot] = p.name
-                row[f"{slot}_team"] = p.team
-                row[f"{slot}_opp"] = p.opp
-                row[f"{slot}_pos"] = p.pos
-
-            row["projections_proj"] = lineup.projection()
-            if pts_col:
-                Ldf = pool.iloc[idxs]
-                if pts_col in Ldf.columns:
-                    total_pts = float(Ldf[pts_col].sum())
-                    row[pts_col] = total_pts
-                    if pts_col.lower() != "score":
-                        row["score"] = total_pts
-                else:
-                    row["score"] = row["projections_proj"]
-            else:
-                row["score"] = row["projections_proj"]
-
-            flags, counts = compute_presence_and_counts(row)
-            feats = compute_features(row)
-            bucket = classify_bucket(flags)
-            row["stack_bucket"] = bucket
-            for k,v in flags.items():
-                row[f"stack_flags__{k}"] = v
-            for k,v in counts.items():
-                row[f"stack_count__{k}"] = v
-            for k,v in feats.items():
-                row[k] = v
-
-            r = compute_reward(row, rl_reward_cfg)
-            row.update({
-                "reward_total": r["total"],
-                "r_base": r["base"],
-                "r_salary_pen": r["salary_pen"],
-                "r_stack_bonus": r["stack_bonus"],
-                "r_feature_pen": r["feature_pen"],
-                "r_flex_bonus": r["flex_bonus"],
-                "r_dist_pen": r["dist_pen"],
-            })
-
+            row.update({"agent": name, "iteration": i, "reward": reward})
+            comps = compute_reward_components(row, env.rl_reward_cfg)
+            row.update({f"rw_{k}": v for k, v in comps.items()})
             rows.append(row)
 
     return pd.DataFrame(rows)

--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -25,9 +25,10 @@ from dfs.stacks import (
     classify_bucket,
     compute_features,
 )
-from dfs.rl_reward import compute_reward
+from dfs.rl_reward import compute_reward, compute_partial_reward
 
-from dfs_rl.utils.lineup import SLOTS
+# explicit slot order
+SLOTS = ["QB", "RB1", "RB2", "WR1", "WR2", "WR3", "TE", "FLEX", "DST"]
 
 class DKNFLEnv(gym.Env if gym else object):
     """Environment for sequential DraftKings NFL lineup construction."""
@@ -43,7 +44,7 @@ class DKNFLEnv(gym.Env if gym else object):
         self.pool = player_pool.reset_index(drop=True).copy()
         self.pool["salary"] = self.pool["salary"].apply(sanitize_salary)
         self.pool["projections_proj"] = self.pool["projections_proj"].astype(float)
-        self.rl_reward_cfg = rl_reward_cfg or {}
+        self.rl_reward_cfg = (rl_reward_cfg or {}).get("weights", rl_reward_cfg or {})
 
         self.players = []
         self.pool_by_pos = {"QB": [], "RB": [], "WR": [], "TE": [], "DST": []}
@@ -69,7 +70,55 @@ class DKNFLEnv(gym.Env if gym else object):
 
         self.reset()
 
+    # --- helpers -------------------------------------------------
+    def _empty_row_dict(self) -> Dict[str, Any]:
+        row: Dict[str, Any] = {"salary": 0.0, "projections_proj": 0.0}
+        for slot in SLOTS:
+            row[slot] = None
+            row[f"{slot}_team"] = None
+            row[f"{slot}_opp"] = None
+            row[f"{slot}_pos"] = None
+        return row
+
+    def _apply_action(self, action: int):
+        slot = SLOTS[self.slot_idx]
+        p = self.players[action]
+        setattr(self.lineup, slot, p)
+        self.cur_row[slot] = p.name
+        self.cur_row[f"{slot}_team"] = p.team
+        self.cur_row[f"{slot}_opp"] = p.opp
+        self.cur_row[f"{slot}_pos"] = p.pos
+        self.cur_row["salary"] += p.salary
+        self.cur_row["projections_proj"] += p.proj
+        self.slot_idx += 1
+        return slot, p
+
+    def _push_preview(self, action: int):
+        slot, p = self._apply_action(action)
+        self._preview_stack.append((slot, p))
+
+    def _pop_preview(self):
+        if not self._preview_stack:
+            return
+        slot, p = self._preview_stack.pop()
+        self.slot_idx -= 1
+        setattr(self.lineup, slot, None)
+        self.cur_row[slot] = None
+        self.cur_row[f"{slot}_team"] = None
+        self.cur_row[f"{slot}_opp"] = None
+        self.cur_row[f"{slot}_pos"] = None
+        self.cur_row["salary"] -= p.salary
+        self.cur_row["projections_proj"] -= p.proj
+
+    def _lineup_complete(self) -> bool:
+        return self.slot_idx >= len(SLOTS)
+
+    def _obs(self):
+        return np.array([0.0], dtype=np.float32), {"action_mask": self._mask()}
+
     def _mask(self) -> np.ndarray:
+        if self.slot_idx >= len(SLOTS):
+            return np.zeros(self.n, dtype=np.int8)
         slot = SLOTS[self.slot_idx]
         used_ids = {p.id for p in self.lineup.players()}
         mask_dict = action_mask_for_slot(
@@ -90,82 +139,48 @@ class DKNFLEnv(gym.Env if gym else object):
         self.lineup = Lineup()
         self.slot_idx = 0
         self.picks: list[int] = []
-        return np.array([0.0], dtype=np.float32), {"action_mask": self._mask()}
+        self.cur_row = self._empty_row_dict()
+        self._preview_stack: list[tuple[str, Player]] = []
+        self._last_partial_reward = 0.0
+        return self._obs()
 
     def step(self, action: int):
         mask = self._mask()
         if action < 0 or action >= self.n or mask[action] == 0:
-            return (
-                np.array([0.0], dtype=np.float32),
-                -0.01,
-                False,
-                False,
-                {"action_mask": mask},
-            )
+            obs, info = self._obs()
+            info["partial_reward"] = self._last_partial_reward
+            return obs, -0.01, False, False, info
 
-        p = self.players[action]
-        slot = SLOTS[self.slot_idx]
-        setattr(self.lineup, slot, p)
         self.picks.append(action)
-        self.slot_idx += 1
-        done = self.slot_idx >= len(SLOTS)
+        self._apply_action(action)
 
+        prev = self._last_partial_reward
+        new_r = compute_partial_reward(self.cur_row, self.rl_reward_cfg)
+        delta = new_r - prev
+        self._last_partial_reward = new_r
+
+        done = self._lineup_complete()
+        reward = float(delta)
+        info_extra: Dict[str, Any] = {}
         if done:
-            sal = self.lineup.salary()
-            lineup_dict: Dict[str,Any] = {"salary": sal}
-            for slot in SLOTS:
-                p = getattr(self.lineup, slot)
-                lineup_dict[slot] = p.name if p else None
-                lineup_dict[f"{slot}_team"] = p.team if p else None
-                lineup_dict[f"{slot}_opp"] = p.opp if p else None
-                lineup_dict[f"{slot}_pos"] = p.pos if p else None
-            lineup_dict["projections_proj"] = self.lineup.projection()
-            lineup_dict["score"] = self.lineup.projection()
-
-            flags, counts = compute_presence_and_counts(lineup_dict)
-            feats = compute_features(lineup_dict)
-            bucket = classify_bucket(flags)
-            lineup_dict["stack_bucket"] = bucket
-            for k,v in flags.items():
-                lineup_dict[f"stack_flags__{k}"] = v
-            for k,v in counts.items():
-                lineup_dict[f"stack_count__{k}"] = v
-            lineup_dict.update(feats)
-
-            r = compute_reward(lineup_dict, self.rl_reward_cfg)
-            lineup_dict.update({
-                "reward_total": r["total"],
-                "r_base": r["base"],
-                "r_salary_pen": r["salary_pen"],
-                "r_stack_bonus": r["stack_bonus"],
-                "r_feature_pen": r["feature_pen"],
-                "r_flex_bonus": r["flex_bonus"],
-                "r_dist_pen": r["dist_pen"],
-            })
-
+            full_r = compute_reward(self.cur_row, self.rl_reward_cfg)
+            reward += float(full_r - new_r)
             if not validate_lineup(
-                self.lineup,
-                cap=DEFAULT_SALARY_CAP,
-                min_pct=self.min_salary_pct,
+                self.lineup, cap=DEFAULT_SALARY_CAP, min_pct=self.min_salary_pct
             ):
-                reward = -100.0
-            else:
-                reward = r["total"]
+                reward += -100.0
+            flags, _ = compute_presence_and_counts(self.cur_row)
+            feats = compute_features(self.cur_row)
+            bucket = classify_bucket(flags)
+            self.cur_row["stack_bucket"] = bucket
+            self.cur_row["double_te"] = feats.get("feat_double_te", 0)
+            self.cur_row["flex_pos"] = feats.get("flex_pos", "")
+            self.cur_row["dst_conflicts"] = feats.get("feat_any_vs_dst", 0)
+            self.cur_row["score"] = self.cur_row.get("projections_proj", 0.0)
+            info_extra.update(self.cur_row)
+            info_extra["lineup_indices"] = self.picks.copy()
 
-            info_dict = {"lineup_indices": self.picks, "lineup_salary": sal}
-            info_dict.update(lineup_dict)
-            return (
-                np.array([1.0], dtype=np.float32),
-                reward,
-                True,
-                False,
-                info_dict,
-            )
-        else:
-            return (
-                np.array([0.0], dtype=np.float32),
-                0.0,
-                False,
-                False,
-                {"action_mask": self._mask()},
-            )
+        obs, info = self._obs()
+        info.update(info_extra)
+        info["partial_reward"] = self._last_partial_reward
+        return obs, reward, done, False, info

--- a/src/pages/02_RL_Arena.py
+++ b/src/pages/02_RL_Arena.py
@@ -27,6 +27,8 @@ n = st.slider("Lineups per agent", 20, 300, 150, 10)
 min_salary_pct = st.sidebar.slider(
     "Min salary spend (% of cap)", 0.90, 1.00, float(os.getenv("MIN_SALARY_PCT", DEFAULT_MIN_SPEND_PCT)), 0.005
 )
+seed = st.sidebar.number_input("Seed", value=0, step=1)
+np.random.seed(int(seed))
 
 if st.button("Run Arena"):
     with st.spinner("Generating lineups..."):
@@ -35,6 +37,7 @@ if st.button("Run Arena"):
             n_lineups_per_agent=n,
             train_pg=True,
             min_salary_pct=min_salary_pct,
+            seed=int(seed),
         )
         st.success("Done")
     if bundle["contest_files"]:
@@ -52,7 +55,12 @@ if st.button("Run Arena"):
                 df = df.merge(payouts, left_on="contest_rank", right_on="rank", how="left")
 
     st.subheader(f"Generated lineups (≥{min_salary_pct:.0%} cap spend)")
-    st.dataframe(df.head(50), width="stretch")
+    cols_to_show = [
+        "agent","iteration","salary","QB","RB1","RB2","WR1","WR2","WR3","TE","FLEX","DST",
+        "projections_proj","score","contest_rank","field_size",
+        "stack_bucket","double_te","flex_pos","dst_conflicts","reward"
+    ]
+    st.dataframe(df[[c for c in cols_to_show if c in df.columns]].head(50), width="stretch")
     st.download_button(
         "Download all lineups (CSV)",
         df.to_csv(index=False).encode(),

--- a/tests/test_stacks_reward.py
+++ b/tests/test_stacks_reward.py
@@ -29,9 +29,8 @@ def test_stack_flags_and_reward():
     feats = compute_features(row)
     assert feats['flex_pos'] == 'WR'
     assert feats['flex_is_wr'] == 1
-    cfg_low = {'stack_bonus': {'QB+WR+OppWR':1.0}}
-    cfg_high = {'stack_bonus': {'QB+WR+OppWR':5.0}}
-    base_input = {**row, **{f'stack_flags__{k}':v for k,v in flags.items()}, **feats}
-    r_low = compute_reward(base_input, cfg_low)
-    r_high = compute_reward(base_input, cfg_high)
-    assert r_high['total'] > r_low['total']
+    cfg_low = {'proj':0.0,'salary_util':0.0,'qb_wr_bonus':1.0,'bringback_bonus':0.0}
+    cfg_high = {'proj':0.0,'salary_util':0.0,'qb_wr_bonus':5.0,'bringback_bonus':0.0}
+    r_low = compute_reward(row, cfg_low)
+    r_high = compute_reward(row, cfg_high)
+    assert r_high > r_low


### PR DESCRIPTION
## Summary
- add component-wise reward helpers and partial lineup evaluation
- shape rewards in DK NFL env and expose stack annotations
- make Greedy/PG agents optimize reward with epsilon-greedy exploration
- log reward components and stack fields in arena and Streamlit page
- include rl_reward config with weights and seed controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b51b7ab1048330a1662ae0d522cd1b