### PR TITLE
Fix missing initialization in DK NFL environment

### DIFF
--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -75,6 +75,7 @@ class DKNFLEnv(gym.Env if gym else object):
 
     # --- helpers -------------------------------------------------
     def _empty_row_dict(self) -> Dict[str, Any]:
+        row: Dict[str, Any] = {"salary": 0, "projections_proj": 0.0}
 
         for slot in SLOTS:
             row[slot] = None


### PR DESCRIPTION
## Summary
- fix NameError in `DKNFLEnv._empty_row_dict` by properly initializing row dictionary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5237af6848330a8297b69acdc96e1