### PR TITLE
Expose projection totals in RL arena and backtester outputs

### DIFF
--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -14,7 +14,17 @@ from dfs.constraints import (
     DEFAULT_MIN_SPEND_PCT,
 )
 
-POINTS_COLS = ["score","dk_points","lineup_points","points","FPTS","total_points"]
+# Columns that might contain lineup point totals
+POINTS_COLS = [
+    "score",
+    "dk_points",
+    "lineup_points",
+    "points",
+    "FPTS",
+    "total_points",
+    "projections_proj",
+    "projections_actpts",
+]
 
 def _find_points_col(df: pd.DataFrame) -> Optional[str]:
     for c in df.columns:

--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -75,7 +75,11 @@ class DKNFLEnv(gym.Env if gym else object):
 
     # --- helpers -------------------------------------------------
     def _empty_row_dict(self) -> Dict[str, Any]:
-        row: Dict[str, Any] = {"salary": 0, "projections_proj": 0.0}
+        row: Dict[str, Any] = {
+            "salary": 0,
+            "projections_proj": 0.0,
+            "projections_actpts": 0.0,
+        }
 
         for slot in SLOTS:
             row[slot] = None
@@ -94,6 +98,7 @@ class DKNFLEnv(gym.Env if gym else object):
         self.cur_row[f"{slot}_pos"] = p.pos
         self.cur_row["salary"] += p.salary
         self.cur_row["projections_proj"] += p.proj
+        self.cur_row["projections_actpts"] += self.player_actpts[action]
 
         self.slot_idx += 1
         return slot, p
@@ -114,6 +119,8 @@ class DKNFLEnv(gym.Env if gym else object):
         self.cur_row[f"{slot}_pos"] = None
         self.cur_row["salary"] -= p.salary
         self.cur_row["projections_proj"] -= p.proj
+        # use player's id to index act pts list
+        self.cur_row["projections_actpts"] -= self.player_actpts[int(p.id)]
 
 
     def _lineup_complete(self) -> bool:

--- a/tests/test_rl_backtester_columns.py
+++ b/tests/test_rl_backtester_columns.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+# Ensure src modules are importable
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dfs_rl.utils.data import load_week_folder
+from dfs_rl.arena import run_tournament
+from backtesting.backtester import backtest_week
+
+
+def test_arena_includes_projection_columns():
+    week_dir = os.path.join("data", "historical", "2019", "2019-09-22")
+    bundle = load_week_folder(week_dir)
+    pool = bundle["projections"]
+    df = run_tournament(pool, n_lineups_per_agent=1, train_pg=False)
+    assert "projections_proj" in df.columns
+    assert "projections_actpts" in df.columns
+
+
+def test_backtester_includes_projection_columns():
+    week_dir = os.path.join("data", "historical", "2019", "2019-09-22")
+    res = backtest_week(week_dir, n_lineups_per_agent=1)
+    gen = res["generated"]
+    assert "projections_proj" in gen.columns
+    assert "projections_actpts" in gen.columns


### PR DESCRIPTION
## Summary
- Track each lineup's projected and actual points inside the DraftKings NFL environment
- Recognize projection columns as valid point totals in the backtester
- Add regression tests ensuring RL arena and backtester output these columns

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5262b70dc8330a9be68211b61751d