### PR TITLE
Expose projection totals in RL Arena and backtester

### DIFF
--- a/backtesting/backtester.py
+++ b/backtesting/backtester.py
@@ -5,7 +5,16 @@ from typing import Dict, Optional
 from dfs_rl.utils.data import load_week_folder
 from dfs_rl.arena import run_tournament
 
-POINTS_COLS = ["score","dk_points","lineup_points","points","FPTS","total_points"]
+POINTS_COLS = [
+    "score",
+    "dk_points",
+    "lineup_points",
+    "points",
+    "FPTS",
+    "total_points",
+    "projections_proj",
+    "projections_actpts",
+]
 
 def _find_points_col(df: pd.DataFrame) -> Optional[str]:
     for c in df.columns:

--- a/src/backtesting/backtester.py
+++ b/src/backtesting/backtester.py
@@ -14,7 +14,17 @@ from dfs.constraints import (
     DEFAULT_MIN_SPEND_PCT,
 )
 
-POINTS_COLS = ["score","dk_points","lineup_points","points","FPTS","total_points"]
+# Columns that might contain lineup point totals
+POINTS_COLS = [
+    "score",
+    "dk_points",
+    "lineup_points",
+    "points",
+    "FPTS",
+    "total_points",
+    "projections_proj",
+    "projections_actpts",
+]
 
 def _find_points_col(df: pd.DataFrame) -> Optional[str]:
     for c in df.columns:

--- a/src/dfs_rl/envs/dk_nfl_env.py
+++ b/src/dfs_rl/envs/dk_nfl_env.py
@@ -75,7 +75,11 @@ class DKNFLEnv(gym.Env if gym else object):
 
     # --- helpers -------------------------------------------------
     def _empty_row_dict(self) -> Dict[str, Any]:
-        row: Dict[str, Any] = {"salary": 0, "projections_proj": 0.0}
+        row: Dict[str, Any] = {
+            "salary": 0,
+            "projections_proj": 0.0,
+            "projections_actpts": 0.0,
+        }
 
         for slot in SLOTS:
             row[slot] = None
@@ -94,6 +98,7 @@ class DKNFLEnv(gym.Env if gym else object):
         self.cur_row[f"{slot}_pos"] = p.pos
         self.cur_row["salary"] += p.salary
         self.cur_row["projections_proj"] += p.proj
+        self.cur_row["projections_actpts"] += self.player_actpts[action]
 
         self.slot_idx += 1
         return slot, p
@@ -114,6 +119,8 @@ class DKNFLEnv(gym.Env if gym else object):
         self.cur_row[f"{slot}_pos"] = None
         self.cur_row["salary"] -= p.salary
         self.cur_row["projections_proj"] -= p.proj
+        # use player's id to index act pts list
+        self.cur_row["projections_actpts"] -= self.player_actpts[int(p.id)]
 
 
     def _lineup_complete(self) -> bool:

--- a/src/pages/02_RL_Arena.py
+++ b/src/pages/02_RL_Arena.py
@@ -56,9 +56,25 @@ if st.button("Run Arena"):
 
     st.subheader(f"Generated lineups (≥{min_salary_pct:.0%} cap spend)")
     cols_to_show = [
-        "agent","iteration","salary","QB","RB1","RB2","WR1","WR2","WR3","TE","FLEX","DST",
-
-        "stack_bucket","double_te","flex_pos","dst_conflicts","reward"
+        "agent",
+        "iteration",
+        "salary",
+        "projections_proj",
+        "projections_actpts",
+        "QB",
+        "RB1",
+        "RB2",
+        "WR1",
+        "WR2",
+        "WR3",
+        "TE",
+        "FLEX",
+        "DST",
+        "stack_bucket",
+        "double_te",
+        "flex_pos",
+        "dst_conflicts",
+        "reward",
     ]
     st.dataframe(df[[c for c in cols_to_show if c in df.columns]].head(50), width="stretch")
     st.download_button(

--- a/src/pages/03_Backtester.py
+++ b/src/pages/03_Backtester.py
@@ -27,7 +27,29 @@ if st.button("Run Backtest"):
         out = backtest_week(week_dir, n_lineups_per_agent=n, min_salary_pct=min_salary_pct)
     st.success("Done")
     st.subheader(f"Generated lineups (≥{min_salary_pct:.0%} cap spend)")
-    st.dataframe(out["generated"].head(50), width="stretch")
+    cols_to_show = [
+        "agent",
+        "iteration",
+        "salary",
+        "projections_proj",
+        "projections_actpts",
+        "QB",
+        "RB1",
+        "RB2",
+        "WR1",
+        "WR2",
+        "WR3",
+        "TE",
+        "FLEX",
+        "DST",
+        "reward",
+        "contest_rank",
+        "field_size",
+        "amount_won",
+    ]
+    gen = out["generated"][ [c for c in cols_to_show if c in out["generated"].columns] ]
+    st.dataframe(gen.head(50), width="stretch")
     if out["scored"] is not None:
         st.subheader("Scored vs contest (rank & winnings)")
-        st.dataframe(out["scored"].head(50), width="stretch")
+        scored = out["scored"][ [c for c in cols_to_show if c in out["scored"].columns] ]
+        st.dataframe(scored.head(50), width="stretch")

--- a/tests/test_rl_backtester_columns.py
+++ b/tests/test_rl_backtester_columns.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+# Ensure src modules are importable
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dfs_rl.utils.data import load_week_folder
+from dfs_rl.arena import run_tournament
+from backtesting.backtester import backtest_week
+
+
+def test_arena_includes_projection_columns():
+    week_dir = os.path.join("data", "historical", "2019", "2019-09-22")
+    bundle = load_week_folder(week_dir)
+    pool = bundle["projections"]
+    df = run_tournament(pool, n_lineups_per_agent=1, train_pg=False)
+    assert "projections_proj" in df.columns
+    assert "projections_actpts" in df.columns
+
+
+def test_backtester_includes_projection_columns():
+    week_dir = os.path.join("data", "historical", "2019", "2019-09-22")
+    res = backtest_week(week_dir, n_lineups_per_agent=1)
+    gen = res["generated"]
+    assert "projections_proj" in gen.columns
+    assert "projections_actpts" in gen.columns


### PR DESCRIPTION
## Summary
- Display `projections_proj` and `projections_actpts` totals for every lineup in RL Arena
- Show projection totals in Backtester outputs and keep them when ranking
- Recognize projection totals as valid point columns for backtesting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5262b70dc8330a9be68211b61751d