### PR TITLE
Add lineup deduplication and diversity controls

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,6 +34,13 @@
   "custom_correlations": {},
 
   "rl": {
+    "epsilon": 0.10,
+    "softmax_temperature": 0.85,
+    "diversity_penalty_weight": 4.0,
+    "min_jaccard_diversity": 0.20,
+    "max_resample_attempts": 25,
+    "max_player_exposure": 0.45,
+    "dedupe_on_collect": true,
     "reward": {
       "base_metric": "actual_points",
       "normalize_by_field": false,

--- a/dfs_rl/agents/pg_agent.py
+++ b/dfs_rl/agents/pg_agent.py
@@ -15,19 +15,31 @@ class TinyPolicy(nn.Module):
 
 class PGAgent:
     """Tiny REINFORCE policy that learns a distribution over players; mask invalid actions."""
-    def __init__(self, n_players: int, lr: float = 1e-3, seed: int = 42):
+    def __init__(self, n_players: int, lr: float = 1e-3, seed: int = 42, cfg: dict | None = None):
         torch.manual_seed(seed)
         self.n = n_players
         self.net = TinyPolicy(n_players)
         self.opt = optim.Adam(self.net.parameters(), lr=lr)
         self.last = None
+        self.rng = np.random.default_rng(seed)
+        self.cfg = cfg or {}
 
     def act(self, mask):
+        eps = self.cfg.get("rl", {}).get("epsilon", 0.1)
+        T = self.cfg.get("rl", {}).get("softmax_temperature", 0.9)
+        legal_idx = np.where(mask == 1)[0]
+        if len(legal_idx) == 0:
+            return 0
         x = torch.zeros(1, self.n)
         logits = self.net(x).detach().numpy().flatten()
         logits[mask == 0] = -1e9
-        probs = np.exp(logits - logits.max()); probs /= probs.sum()
-        a = int(np.random.choice(np.arange(self.n), p=probs))
+        if self.rng.random() < eps:
+            a = int(self.rng.choice(legal_idx))
+        else:
+            s = logits[legal_idx] / max(T, 1e-6)
+            s = s - s.max()
+            p = np.exp(s); p /= p.sum()
+            a = int(self.rng.choice(legal_idx, p=p))
         self.last = (torch.tensor(logits).unsqueeze(0), a, torch.tensor(mask, dtype=torch.float32).unsqueeze(0))
         return a
 

--- a/dfs_rl/arena.py
+++ b/dfs_rl/arena.py
@@ -1,10 +1,13 @@
 from typing import List, Tuple, Optional
+from collections import Counter
 import numpy as np
 import pandas as pd
 
-from dfs_rl.envs.dk_nfl_env import DKNFLEnv
+from dfs_rl.envs.dk_nfl_env import DKNFLEnv, compute_reward
 from dfs_rl.agents.random_agent import RandomAgent
 from dfs_rl.agents.pg_agent import PGAgent
+from dfs_rl.utils.lineups import lineup_key, jaccard_similarity, SLOTS
+from src.dfs.stacks import compute_features, compute_presence_and_counts, classify_bucket
 
 POINTS_COLS = [
     "projections_actpts",
@@ -36,21 +39,93 @@ def _run_agent(env: DKNFLEnv, agent, train: bool) -> Tuple[list,int,float]:
             if train and hasattr(agent, "update"):
                 agent.update(total)
             return info.get("lineup_indices", []), steps, total
+def _build_lineup(pool: pd.DataFrame, idxs: List[int]) -> dict:
+    lineup: dict = {}
+    for slot, idx in zip(SLOTS, idxs):
+        row = pool.iloc[idx]
+        lineup[f"{slot}"] = row.get("name")
+        pid = row.get("player_id") or row.get("id")
+        if pid is not None:
+            lineup[f"{slot}_id"] = pid
+        lineup[f"{slot}_team"] = row.get("team")
+        lineup[f"{slot}_opp"] = row.get("opp")
+        lineup[f"{slot}_pos"] = row.get("pos")
+    return lineup
 
-def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150, train_pg: bool = True) -> pd.DataFrame:
+
+def run_tournament(pool: pd.DataFrame, n_lineups_per_agent: int = 150,
+                   train_pg: bool = True, cfg: Optional[dict] = None) -> pd.DataFrame:
+    cfg = cfg or {}
     env = DKNFLEnv(pool)
     n = len(pool)
     agents = {
         "random": RandomAgent(seed=1),
-        "pg": PGAgent(n_players=n, seed=2),
+        "pg": PGAgent(n_players=n, seed=2, cfg=cfg),
     }
 
-    pts_col = _find_points_col(pool)
+    rl_cfg = cfg.get("rl", {})
+    pts_col = _find_points_col(pool) or "projections_proj"
+    seen_keys_global = set()
+    exposure_count: Counter[str] = Counter()
+
+    def accept_lineup_if_unique(lu: dict) -> Tuple[bool, tuple]:
+        key = lineup_key(lu)
+        if key in seen_keys_global:
+            return False, key
+        max_exp = rl_cfg.get("max_player_exposure")
+        if max_exp is not None:
+            pool_size = cfg.get("arena_pool_size") or 1
+            cap = int(max_exp * pool_size)
+            for pid in key:
+                if exposure_count[pid] >= cap:
+                    return False, key
+        min_div = rl_cfg.get("min_jaccard_diversity")
+        if min_div is not None and seen_keys_global:
+            ids = list(key)
+            comp = list(seen_keys_global)[-200:]
+            if comp:
+                sim = max(jaccard_similarity(ids, list(k)) for k in comp)
+                if sim >= min_div:
+                    return False, key
+        seen_keys_global.add(key)
+        for pid in key:
+            exposure_count[pid] += 1
+        return True, key
 
     rows = []
     for name, agent in agents.items():
         for i in range(n_lineups_per_agent):
-            idxs, steps, reward = _run_agent(env, agent, train=(train_pg and name == "pg"))
-            L = pool.iloc[idxs].copy()
+            attempts = 0
+            accepted = False
+            key = tuple()
+            lineup_dict = {}
+            while attempts < rl_cfg.get("max_resample_attempts", 25) and not accepted:
+                idxs, steps, base_reward = _run_agent(env, agent, train=(train_pg and name == "pg"))
+                lineup_dict = _build_lineup(pool, idxs)
+                accepted, key = accept_lineup_if_unique(lineup_dict)
+                attempts += 1
+            base_points = float(pool.loc[idxs, pts_col].sum())
+            stack_bonus = 0.0
+            reward = compute_reward(lineup_dict, base_points, stack_bonus, rl_cfg, seen_keys_global)
+            feats = compute_features(lineup_dict)
+            flags, _ = compute_presence_and_counts(lineup_dict)
+            bucket = classify_bucket(flags)
+            rows.append({
+                "agent": name,
+                "reward": reward,
+                "lineup_key": "|".join(key),
+                "stack_bucket": bucket,
+                "double_te": feats.get("feat_double_te"),
+                "flex_pos": feats.get("flex_pos"),
+                "dst_conflicts": feats.get("feat_any_vs_dst"),
+                "is_duplicate": 0 if accepted else 1
+            })
 
-    return pd.DataFrame(rows)
+    df = pd.DataFrame(rows)
+    dupes = int(df.duplicated("lineup_key", keep=False).sum())
+    if rl_cfg.get("dedupe_on_collect", True):
+        df = (df.sort_values(["reward"], ascending=False)
+                .drop_duplicates("lineup_key", keep="first")
+                .reset_index(drop=True))
+    df.attrs["duplicates"] = dupes
+    return df

--- a/dfs_rl/utils/lineups.py
+++ b/dfs_rl/utils/lineups.py
@@ -1,0 +1,21 @@
+from collections import Counter
+
+SLOTS = ["QB","RB1","RB2","WR1","WR2","WR3","TE","FLEX","DST"]
+
+
+def lineup_key(lineup_dict):
+    """Canonical key independent of slot order for non-DST skill players."""
+    ids = []
+    for s in SLOTS:
+        pid = lineup_dict.get(f"{s}_id") or lineup_dict.get(s)
+        if pid is not None:
+            ids.append(str(pid))
+    ids.sort()
+    return tuple(ids)
+
+
+def jaccard_similarity(a_ids, b_ids):
+    A, B = set(a_ids), set(b_ids)
+    if not A and not B:
+        return 0.0
+    return len(A & B) / float(len(A | B))

--- a/sample.config.json
+++ b/sample.config.json
@@ -34,6 +34,13 @@
   "custom_correlations": {},
 
   "rl": {
+    "epsilon": 0.10,
+    "softmax_temperature": 0.85,
+    "diversity_penalty_weight": 4.0,
+    "min_jaccard_diversity": 0.20,
+    "max_resample_attempts": 25,
+    "max_player_exposure": 0.45,
+    "dedupe_on_collect": true,
     "reward": {
       "base_metric": "actual_points",
       "normalize_by_field": false,


### PR DESCRIPTION
## Summary
- add RL config knobs for exploration, diversity penalty, and exposure caps
- track canonical lineup keys and jaccard similarity
- enforce unique lineups with optional dedupe and updated PG agent sampling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a60b7eb483309ee2bd2ae5ec0f3a