### PR TITLE
Handle existing exposure columns when attaching historical outcomes

### DIFF
--- a/src/dfs_rl/utils/historical_outcomes.py
+++ b/src/dfs_rl/utils/historical_outcomes.py
@@ -116,6 +116,10 @@ def attach_historical_outcomes(
     # Compose the columns we will expose
     expose_cols = ['contest_rank','amount_won','field_size','entries_per_user','entry_fee','contest_name','matches_found']
 
+    # If this function is called multiple times, make sure we don't carry over
+    # previous exposure columns which would clash during joins/merges below.
+    g = g.drop(columns=[c for c in expose_cols if c in g.columns], errors='ignore')
+
     if hist.empty:
         for c in expose_cols:
             g[c] = pd.NA

--- a/tests/test_historical_outcomes.py
+++ b/tests/test_historical_outcomes.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from dfs_rl.utils.historical_outcomes import (
+    attach_historical_outcomes,
+    load_outcomes_for_date,
+    ROSTER_SLOTS,
+)
+
+
+def test_attach_historical_outcomes_handles_existing_columns():
+    base_dir = os.path.join("data", "historical")
+    date_like = "2019-09-22"
+    hist = load_outcomes_for_date(base_dir, date_like)
+    assert not hist.empty
+
+    lineup_cols = ROSTER_SLOTS + ["contest_id"]
+    generated = hist[lineup_cols].head(1).copy()
+
+    first = attach_historical_outcomes(generated, date_like, base_dir)
+    second = attach_historical_outcomes(first, date_like, base_dir)
+
+    assert second["contest_rank"].iloc[0] == first["contest_rank"].iloc[0]


### PR DESCRIPTION
## Summary
- drop previously attached exposure columns before merging historical outcomes
- add regression test ensuring repeated calls succeed without column overlap

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6536c56ec8330815329490ad5eb13