### PR TITLE
Fix contest metadata integration for arena and backtester

### DIFF
--- a/tests/test_historical_outcomes.py
+++ b/tests/test_historical_outcomes.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pandas as pd
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
 
@@ -23,3 +24,15 @@ def test_attach_historical_outcomes_handles_existing_columns():
     second = attach_historical_outcomes(first, date_like, base_dir)
 
     assert second["contest_rank"].iloc[0] == first["contest_rank"].iloc[0]
+
+
+def test_attach_historical_outcomes_preserves_existing_when_no_match():
+    base_dir = os.path.join("data", "historical")
+    date_like = "2019-09-08"
+    lineup = {s: f"{s}_player" for s in ROSTER_SLOTS}
+    lineup.update({"contest_rank": 7, "amount_won": 0.0})
+    generated = pd.DataFrame([lineup])
+
+    out = attach_historical_outcomes(generated, date_like, base_dir)
+    assert out["contest_rank"].iloc[0] == 7
+    assert out["matches_found"].iloc[0] == 0

--- a/tests/test_rl_backtester_columns.py
+++ b/tests/test_rl_backtester_columns.py
@@ -24,3 +24,13 @@ def test_backtester_includes_projection_columns():
     gen = res["generated"]
     assert "projections_proj" in gen.columns
     assert "projections_actpts" in gen.columns
+
+
+def test_backtester_uses_score_for_rank_and_metadata():
+    week_dir = os.path.join("data", "historical", "2019", "2019-09-22")
+    res = backtest_week(week_dir, n_lineups_per_agent=1)
+    gen = res["generated"]
+    assert "contest_rank" in gen.columns
+    assert gen["contest_rank"].notna().any()
+    for col in ["field_size", "entries_per_user", "entry_fee"]:
+        assert col in gen.columns


### PR DESCRIPTION
## Summary
- compute contest ranks even when lineup and leaderboard use different score column names
- surface contest metadata (field size, entries per user, entry fee, name) in RL Arena and backtester outputs
- preserve existing rank/amount won when attaching historical outcomes so missing matches don't wipe values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b656613bf88330b8fd5b9174771374