### PR TITLE
Skip missing opponent stack rules

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -503,6 +503,12 @@ class NFL_Optimizer:
 
                         opp_team = pos_key_players[0]["Opponent"]
 
+                        if (
+                            stack_type in ["opp-team", "same-game"]
+                            and opp_team not in self.players_by_team
+                        ):
+                            continue
+
                         for pos_key_player in pos_key_players:
                             stack_players = []
                             if stack_type == "same-team":
@@ -608,6 +614,12 @@ class NFL_Optimizer:
 
                         opp_team = opp_team[0]["Opponent"]
                         if team in excluded_teams:
+                            continue
+
+                        if (
+                            stack_type in ["opp-team", "same-game"]
+                            and opp_team not in self.players_by_team
+                        ):
                             continue
 
                         limit_players = []

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -40,3 +40,16 @@ def test_optimizer_handles_players_removed_from_player_dict():
 
     # Should not raise KeyError
     opt.optimize()
+
+
+def test_optimizer_skips_stack_when_opponent_missing():
+    opt = NFL_Optimizer(site="dk", num_lineups=1, num_uniques=1)
+
+    team = next(iter(opt.players_by_team.keys()))
+    opp_team = opt.players_by_team[team]["QB"][0]["Opponent"]
+
+    if opp_team in opt.players_by_team:
+        del opt.players_by_team[opp_team]
+
+    # Should not raise KeyError when opponent team is missing
+    opt.optimize()


### PR DESCRIPTION
## Summary
- avoid KeyError by skipping stack rules when an opposing team isn't in the player pool
- cover optimizer against missing opponent stacks with new test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb835fb23c8330ae6e879a3ca09187