### PR TITLE
fix(optimizer): report deterministic projection to CSV

### DIFF
--- a/src/lineup_writer_patch.py
+++ b/src/lineup_writer_patch.py
@@ -110,8 +110,15 @@ def write_lineup_csv(
                 _slot_str(slots["QB"]), _slot_str(slots["RB1"]), _slot_str(slots["RB2"]),
                 _slot_str(slots["WR1"]), _slot_str(slots["WR2"]), _slot_str(slots["WR3"]),
                 _slot_str(slots["TE"]), _slot_str(slots["FLEX"]), _slot_str(slots["DST"]),
-                round(total_salary,2), round(total_proj,2), 0.0, round(total_act,2), round(total_ceil,2),
+                round(total_salary,2), round(total_proj,2), round(total_proj,2), round(total_act,2), round(total_ceil,2),
                 round(own_sum,6), own_prod, round(stddev,6), p_vs_dst, stack_str
             ]
             assert len(row) == len(HEADER), f"[lineup {i}] Row has {len(row)} fields; expected {len(HEADER)}"
             w.writerow(row)
+
+        # Optional: add a simple footer with optimal and floor if provided via environment
+        opt = os.environ.get("OPTIMAL_FPTS")
+        floor = os.environ.get("MIN_FPTS_FLOOR")
+        if opt or floor:
+            w.writerow([])
+            w.writerow(["# Optimal FPTS", opt or "", "# Min FPTS Floor", floor or ""])


### PR DESCRIPTION
## Summary
- expose optimal FPTS and min off-optimal floor for later reporting
- store deterministic projections in lineups and CSV output
- include optional CSV footer with optimal and floor values

## Testing
- `pytest` *(fails: tests/test_gpp_simulator.py::test_lamar_jackson_gets_id_without_mismatch, tests/test_gpp_simulator.py::test_output_includes_stack_columns)*

------
https://chatgpt.com/codex/tasks/task_e_68bcceb2483c8330b8a54b77b967be94