### PR TITLE
fix(writer): enforce DK/FD salary cap and floor during CSV write

### DIFF
--- a/src/lineup_writer_patch.py
+++ b/src/lineup_writer_patch.py
@@ -99,6 +99,26 @@ def write_lineup_csv(
 
             total_salary = _sum(nine, "salary")
             total_proj   = _sum(nine, "proj")
+
+            # --- Begin: hard guard on salary bounds (independent of optimizer) ---
+            cap_env   = os.environ.get("OPT_CAP")
+            floor_env = os.environ.get("OPT_FLOOR")
+            try:
+                cap   = int(cap_env)   if cap_env   is not None else 50000
+                floor = int(floor_env) if floor_env is not None else 45000
+            except Exception:
+                cap, floor = 50000, 45000  # DK defaults if env missing
+
+            if not (floor - 1e-6 <= total_salary <= cap + 1e-6):
+                raise AssertionError(
+                    f"[lineup {i}] Salary {total_salary} out of bounds "
+                    f"(cap={cap}, floor={floor}). "
+                    f"QB={_slot_str(slots['QB'])}, RB1={_slot_str(slots['RB1'])}, RB2={_slot_str(slots['RB2'])}, "
+                    f"WR1={_slot_str(slots['WR1'])}, WR2={_slot_str(slots['WR2'])}, WR3={_slot_str(slots['WR3'])}, "
+                    f"TE={_slot_str(slots['TE'])}, FLEX={_slot_str(slots['FLEX'])}, DST={_slot_str(slots['DST'])}"
+                )
+            # --- End: hard guard on salary bounds ---
+
             total_act    = _sum(nine, "act")
             total_ceil   = _sum(nine, "ceil")
             own_sum      = _own_sum(nine)

--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -1209,6 +1209,15 @@ class NFL_Optimizer:
         if hasattr(self, "min_fpts_floor"):
             os.environ["MIN_FPTS_FLOOR"] = f"{self.min_fpts_floor:.4f}"
 
+        # BEGIN: pass site/cap/floor to writer for independent verification
+        import os as _os
+        _cap  = 50000 if self.site == "dk" else 60000
+        _floor = self.min_lineup_salary if self.min_lineup_salary else (45000 if self.site == "dk" else 55000)
+        _os.environ["OPT_SITE"] = str(self.site)
+        _os.environ["OPT_CAP"] = str(int(_cap))
+        _os.environ["OPT_FLOOR"] = str(int(_floor))
+        # END: pass site/cap/floor to writer
+
         write_lineup_csv(
             all_lineups_as_players,
             out_path=out_path,


### PR DESCRIPTION
## Summary
- pass optimizer site/cap/floor info to writer via environment variables
- add independent salary cap/floor assertion to lineup CSV writer

## Testing
- `pytest -q` *(fails: AssertionError in tests/test_gpp_simulator.py::test_lamar_jackson_gets_id_without_mismatch, IndexError in tests/test_gpp_simulator.py::test_output_includes_stack_columns)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdd4ec9a08330afbc6aa23c571f69