### PR TITLE
Normalize player names and add aliases

### DIFF
--- a/src/player_ids_flex.py
+++ b/src/player_ids_flex.py
@@ -28,7 +28,11 @@ def _norm_name(n: str) -> str:
     # A.J. -> AJ, squeeze whitespace
     n = re.sub(r"\.", "", n)
     n = re.sub(r"\s+", " ", n)
-    return n
+    # Drop common suffixes and trailing roman numerals
+    n = re.sub(r"\b(jr|sr|ii|iii|iv|v)\b", "", n, flags=re.IGNORECASE)
+    n = re.sub(r"\b[ivxlcdm]+\b$", "", n, flags=re.IGNORECASE)
+    n = n.strip()
+    return n.lower()
 
 def _detect_schema(cols):
     s = {c.lower(): c for c in cols}


### PR DESCRIPTION
## Summary
- Normalize player names by removing suffixes and roman numerals in `player_ids_flex._norm_name`
- Use normalized names in projection loading and player ID matching
- Add first-initial + last-name aliases when loading player IDs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0dfc3aae88330985f21ef17a680f0