### PR TITLE
Normalize player names and expand alias matching

### DIFF
--- a/src/player_ids_flex.py
+++ b/src/player_ids_flex.py
@@ -31,7 +31,8 @@ def _norm_name(n: str) -> str:
     # Drop common suffixes and trailing roman numerals
     n = re.sub(r"\b(jr|sr|ii|iii|iv|v)\b", "", n, flags=re.IGNORECASE)
     n = re.sub(r"\b[ivxlcdm]+\b$", "", n, flags=re.IGNORECASE)
-    n = n.strip()
+    # Collapse any whitespace introduced by removals
+    n = re.sub(r"\s+", " ", n).strip()
     return n.lower()
 
 def _detect_schema(cols):


### PR DESCRIPTION
## Summary
- Normalize names by stripping suffixes and roman numerals
- Generate broad alias variants with team-aware fallbacks
- Improve unmatched player diagnostics and name normalization in projections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f1844c1c833086a60fc8353ad1fd