### PR TITLE
Add name alias mappings to configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,6 +33,11 @@
   "team_limits": {},
   "custom_correlations": {},
 
+  "name_aliases": {
+    "Pat Mahomes": "Patrick Mahomes",
+    "Giants D": "New York Giants DST"
+  },
+
   "rl": {
     "epsilon": 0.10,
     "softmax_temperature": 0.85,

--- a/sample.config.json
+++ b/sample.config.json
@@ -33,6 +33,11 @@
   "team_limits": {},
   "custom_correlations": {},
 
+  "name_aliases": {
+    "Pat Mahomes": "Patrick Mahomes",
+    "Giants D": "New York Giants DST"
+  },
+
   "rl": {
     "epsilon": 0.10,
     "softmax_temperature": 0.85,


### PR DESCRIPTION
## Summary
- add configurable `name_aliases` to map short names to canonical player names
- mirror alias configuration in sample config

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0f353bb4083309288cb74fc719723