### PR TITLE
Add initial-last alias fallback for player ID lookups

### DIFF
--- a/src/nfl_optimizer.py
+++ b/src/nfl_optimizer.py
@@ -427,6 +427,16 @@ class NFL_Optimizer:
                         if info:
                             break
 
+            if not info:
+                parts = name_canon.split()
+                if len(parts) >= 2:
+                    init_alias = f"{parts[0][0]} {parts[-1]}".replace("-", "#")
+                    info = self.player_ids.get((init_alias, pos)) or \
+                           self.player_ids.get((f"{init_alias} {team}", pos))
+                    for alias in (init_alias, f"{init_alias} {team}"):
+                        if alias.strip() and alias not in name_variants:
+                            name_variants.append(alias)
+
             rec["_tried_aliases"] = name_variants
             if info:
                 rec["ID"] = info["ID"]


### PR DESCRIPTION
## Summary
- Enhance player ID loading to try a first-initial plus last-name alias when direct matches fail

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0f4d155bc8330a14adb637469b510