### PR TITLE
Normalize player names

### DIFF
--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -22,9 +22,17 @@ import sys
 
 from utils import get_data_path, get_config_path
 
-@jit(nopython=True)  
+@jit(nopython=True)
 def salary_boost(salary, max_salary):
     return (salary / max_salary) ** 2
+
+
+def _normalize_name(name: str) -> str:
+    """Normalize player names to ensure consistent dictionary keys."""
+    normalized = name.replace("-", "#").lower().strip()
+    normalized = normalized.replace(".", "")
+    normalized = re.sub(r"\s+(jr|sr|ii|iii|iv|v|vi|vii|viii|ix|x)$", "", normalized)
+    return normalized
 
 class NFL_Showdown_Simulator:
     def __init__(
@@ -312,7 +320,7 @@ class NFL_Showdown_Simulator:
                     if row.get("firstname") and row.get("lastname"):
                         names.add(f"{row['firstname']} {row['lastname']}")
                     for name in names:
-                        player_name = name.replace("-", "#").lower().strip()
+                        player_name = _normalize_name(name)
                         if (player_name, position, team) in self.player_dict:
                             self.player_dict[(player_name, position, team)]["ID"] = str(row["draftableid"])
                             self.player_dict[(player_name, position, team)]["Team"] = team
@@ -334,7 +342,7 @@ class NFL_Showdown_Simulator:
                         names.add(f"{row['first name']} {row['last name']}")
                     for position in ["CPT", "FLEX"]:
                         for name in names:
-                            player_name = name.replace("-", "#").lower().strip()
+                            player_name = _normalize_name(name)
                             if (player_name, position, team) in self.player_dict:
                                 key = f"{position}:{row.get('id', '')}"
                                 self.player_dict[(player_name, position, team)]["UniqueKey"] = key
@@ -349,7 +357,7 @@ class NFL_Showdown_Simulator:
             for primary_player in self.correlation_rules.keys():
                 # Convert primary_player to the consistent format
                 formatted_primary_player = (
-                    primary_player.replace("-", "#").lower().strip()
+                    _normalize_name(primary_player)
                 )
                 for (
                     player_name,
@@ -362,7 +370,7 @@ class NFL_Showdown_Simulator:
                         ].items():
                             # Convert second_entity to the consistent format
                             formatted_second_entity = (
-                                second_entity.replace("-", "#").lower().strip()
+                                _normalize_name(second_entity)
                             )
 
                             # Check if the formatted_second_entity is a player name
@@ -423,7 +431,7 @@ class NFL_Showdown_Simulator:
             for c in self.correlation_rules.keys():
                 for k in self.player_dict:
                     if (
-                        c.replace("-", "#").lower().strip()
+                        _normalize_name(c)
                         in self.player_dict[k].values()
                     ):
                         for v in self.correlation_rules[c].keys():
@@ -443,7 +451,7 @@ class NFL_Showdown_Simulator:
         with open(path, encoding="utf-8-sig") as file:
             reader = csv.DictReader(self.lower_first(file))
             for row in reader:
-                player_name = row["name"].replace("-", "#").lower().strip()
+                player_name = _normalize_name(row["name"])
                 try:
                     fpts = float(row["projections_proj"])
                 except:

--- a/tests/data/player_ids.csv
+++ b/tests/data/player_ids.csv
@@ -1,0 +1,5 @@
+start_date,draftableid,displayname,position,firstname,lastname,shortname
+2023-09-01,1,Calvin Austin III,FLEX,Calvin,Austin III,PIT
+2023-09-01,1,Calvin Austin III,CPT,Calvin,Austin III,PIT
+2023-09-01,2,Travis Etienne Jr.,FLEX,Travis,Etienne Jr.,JAX
+2023-09-01,2,Travis Etienne Jr.,CPT,Travis,Etienne Jr.,JAX

--- a/tests/data/projections.csv
+++ b/tests/data/projections.csv
@@ -1,0 +1,3 @@
+name,salary,team,pos,projections_proj,projections_actpts,projections_projown
+Calvin Austin III,5000,PIT,WR,10,0,5
+Travis Etienne Jr.,8000,JAX,RB,18,0,15

--- a/tests/test_name_normalization.py
+++ b/tests/test_name_normalization.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
+import nfl_showdown_simulator
+from nfl_showdown_simulator import NFL_Showdown_Simulator, _normalize_name
+
+
+def test_generational_suffixes_match(monkeypatch):
+    # Avoid heavy optimizer/correlation work in tests
+    monkeypatch.setattr(NFL_Showdown_Simulator, "get_optimal", lambda self: None)
+    monkeypatch.setattr(NFL_Showdown_Simulator, "load_correlation_rules", lambda self: None)
+
+    original_load_config = NFL_Showdown_Simulator.load_config
+
+    def patched_load_config(self):
+        original_load_config(self)
+        self.config.setdefault("allow_def_vs_qb_cpt", False)
+
+    monkeypatch.setattr(NFL_Showdown_Simulator, "load_config", patched_load_config)
+
+    data_dir = os.path.join(os.path.dirname(__file__), "data")
+
+    def fake_get_data_path(site, filename):
+        return os.path.join(data_dir, filename)
+
+    monkeypatch.setattr(nfl_showdown_simulator, "get_data_path", fake_get_data_path)
+
+    sim = NFL_Showdown_Simulator(
+        site="dk",
+        field_size=1,
+        num_iterations=1,
+        use_contest_data=False,
+        use_lineup_input=False,
+    )
+
+    players = [
+        ("Calvin Austin III", "PIT", "1"),
+        ("Travis Etienne Jr.", "JAX", "2"),
+    ]
+
+    for name, team, pid in players:
+        norm = _normalize_name(name)
+        key = (norm, "FLEX", team)
+        assert key in sim.player_dict
+        assert sim.player_dict[key]["ID"] == pid
+        # also ensure CPT entry uses same ID
+        key_cpt = (norm, "CPT", team)
+        assert key_cpt in sim.player_dict
+        assert sim.player_dict[key_cpt]["ID"] == pid


### PR DESCRIPTION
## Summary
- add `_normalize_name` helper to standardize player name keys
- apply normalization across projection and ID loading for consistent player_dict keys
- test generational suffix handling to ensure IDs are preserved

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c104aa14708330a2274d5bcb2ebbe2