### PR TITLE
Integrate skew-aware risk model

### DIFF
--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -14,7 +14,8 @@ import statistics
 import itertools
 import collections
 import re
-from scipy.stats import norm, kendalltau, multivariate_normal, gamma
+from scipy.stats import norm, kendalltau, gamma
+from risk_model import build_player_risk, sample_skewed_outcomes
 import matplotlib.pyplot as plt
 import seaborn as sns
 from numba import njit, jit
@@ -460,7 +461,7 @@ class NFL_Showdown_Simulator:
         # Read projections into a dictionary
         with open(path, encoding="utf-8-sig") as file:
             reader = csv.DictReader(self.lower_first(file))
-            for row in reader:
+            for idx, row in enumerate(reader):
                 player_name = _norm_name(row["name"]).replace("-", "#")
                 try:
                     fpts = float(row["projections_proj"])
@@ -487,33 +488,52 @@ class NFL_Showdown_Simulator:
                     if "D" in position:
                         position = ["DST"]
                 pos = position[0]
-                if "fantasyyear_consistency" in row:
-                    if row["fantasyyear_consistency"] == "" or float(row["fantasyyear_consistency"]) == 0:
-                        if position == "QB":
-                            stddev = fpts * self.default_qb_var
-                        elif position == "DST":
-                            stddev = fpts * self.default_def_var
-                        else:
-                            stddev = fpts * self.default_skillpos_var
-                    else:
-                        stddev = float(row["fantasyyear_consistency"])
-                else:
-                    if position == "QB":
-                        stddev = fpts * self.default_qb_var
-                    elif position == "DST":
-                        stddev = fpts * self.default_def_var
-                    else:
-                        stddev = fpts * self.default_skillpos_var
-                # check if ceiling exists in row columns
-                if "ceiling" in row:
-                    if row["ceiling"] == "" or float(row["ceiling"]) == 0:
-                        ceil = fpts + stddev
-                    else:
-                        ceil = float(row["ceiling"])
-                else:
-                    ceil = fpts + stddev
+                risk = build_player_risk(
+                    mean_fpts=fpts,
+                    position=pos,
+                    default_qb_var=self.default_qb_var,
+                    default_skill_var=self.default_skillpos_var,
+                    default_def_var=self.default_def_var,
+                    ceiling=(row.get("projections_ceiling") or row.get("ceiling")),
+                    floor=(row.get("projections_floor") or row.get("floor")),
+                    consistency_raw=row.get("fantasyyear_consistency"),
+                    upside_raw=row.get("fantasyyear_upside"),
+                    duds_raw=row.get("fantasyyear_duds"),
+                    beta_consistency=1.0,
+                )
+                stddev = risk["sigma_eff"]
+                sigma_base = risk["sigma_base"]
+                r_plus = risk["r_plus"]
+                r_minus = risk["r_minus"]
+                ceil = float(
+                    row.get("projections_ceiling")
+                    or row.get("ceiling")
+                    or (fpts + stddev)
+                )
                 if row["salary"]:
                     sal = float(row["salary"].replace(",", ""))
+                if os.environ.get("RISK_DEBUG", "0") == "1" and idx < 3:
+                    print(
+                        "RISK:",
+                        row.get("name"),
+                        pos,
+                        "mean=",
+                        fpts,
+                        "σ_base=",
+                        round(sigma_base, 2),
+                        "σ_eff=",
+                        round(stddev, 2),
+                        "r+=",
+                        round(r_plus, 2),
+                        "r-=",
+                        round(r_minus, 2),
+                        "cons=",
+                        row.get("fantasyyear_consistency"),
+                        "up=",
+                        row.get("fantasyyear_upside"),
+                        "dn=",
+                        row.get("fantasyyear_duds"),
+                    )
                 if pos == "QB":
                     corr = {
                         "QB": 1,
@@ -635,6 +655,9 @@ class NFL_Showdown_Simulator:
                     "ID": "",
                     "Salary": sal,
                     "StdDev": stddev,
+                    "SigmaBase": sigma_base,
+                    "RPlus": r_plus,
+                    "RMinus": r_minus,
                     "Ceiling": ceil,
                     "Ownership": own,
                     "Correlations": corr,
@@ -668,8 +691,11 @@ class NFL_Showdown_Simulator:
                     "Opp": "",
                     "ID": "",
                     "Salary": cpt_sal,
-                    "StdDev": stddev,
-                    "Ceiling": ceil,
+                    "StdDev": 1.5 * stddev,
+                    "SigmaBase": 1.5 * sigma_base,
+                    "RPlus": r_plus,
+                    "RMinus": r_minus,
+                    "Ceiling": 1.5 * ceil,
                     "Ownership": cptOwn,
                     "Correlations": corr,
                     "Player Correlations": {},
@@ -1231,35 +1257,13 @@ class NFL_Showdown_Simulator:
             for i in range(N):
                 for j in range(N):
                     if i == j:
-                        matrix[i][j] = (
-                            players[i]["StdDev"] ** 2
-                        )  # Variance on the diagonal
+                        matrix[i][j] = players[i]["StdDev"] ** 2
                         corr_matrix[i][j] = 1
                     else:
-                        matrix[i][j] = (
-                            get_corr_value(players[i], players[j])
-                            * players[i]["StdDev"]
-                            * players[j]["StdDev"]
-                        )
-                        corr_matrix[i][j] = get_corr_value(players[i], players[j])
+                        c = get_corr_value(players[i], players[j])
+                        matrix[i][j] = c * players[i]["StdDev"] * players[j]["StdDev"]
+                        corr_matrix[i][j] = c
             return matrix, corr_matrix
-
-
-        def ensure_positive_semidefinite(matrix):
-            eigs = np.linalg.eigvals(matrix)
-            if np.any(eigs < 0):
-                jitter = abs(min(eigs)) + 1e-6  # a small value
-                matrix += np.eye(len(matrix)) * jitter
-
-            # Given eigenvalues and eigenvectors from previous code
-            eigenvalues, eigenvectors = np.linalg.eigh(matrix)
-
-            # Set negative eigenvalues to zero
-            eigenvalues[eigenvalues < 0] = 0
-
-            # Reconstruct the matrix
-            matrix = eigenvectors.dot(np.diag(eigenvalues)).dot(eigenvectors.T)
-            return matrix
 
         # Filter out players with projections less than or equal to 0
         team1 = [
@@ -1275,17 +1279,22 @@ class NFL_Showdown_Simulator:
 
         game = team1 + team2
         covariance_matrix, corr_matrix = build_covariance_matrix(game)
-        covariance_matrix = ensure_positive_semidefinite(covariance_matrix)
+        corr = np.array(corr_matrix, dtype=float)
 
-        try:
-            samples = multivariate_normal.rvs(
-                mean=[player["Fpts"] for player in game],
-                cov=covariance_matrix,
-                size=num_iterations,
-            )
-        except Exception as e:
-            print(f"{team1_id}, {team2_id}, bad matrix: {str(e)}")
-            return {}
+        means = [player["Fpts"] for player in game]
+        risks = [
+            {
+                "sigma_base": player["SigmaBase"],
+                "r_plus": player["RPlus"],
+                "r_minus": player["RMinus"],
+                "sigma_eff": player["StdDev"],
+            }
+            for player in game
+        ]
+        rng = np.random.default_rng(getattr(self, "seed", None))
+        samples = np.vstack(
+            [sample_skewed_outcomes(rng, means, risks, corr) for _ in range(num_iterations)]
+        )
 
         player_samples = [samples[:, i] for i in range(len(game))]
 

--- a/src/risk_model.py
+++ b/src/risk_model.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+risk_model.py
+
+Converts projections + (consistency, upside, duds) into a per-player risk model:
+- sigma_base: σ in fantasy points from floor/ceiling (or position defaults)
+- consistency scaling: probability within ±1σ adjusts σ (not σ itself)
+- sign-dependent scales r_plus/r_minus from ±0.5σ tail rates (skew)
+- sigma_eff: effective σ for covariance (RMS of sign scales)
+
+Optimizer: use draw_optimizer_noise_points for sign-aware jitter.
+Simulator: use build_covariance_from_corr + sample_skewed_outcomes for skewed sampling.
+"""
+
+from typing import Optional, Dict, Tuple, Sequence
+import math
+from statistics import NormalDist
+import numpy as np
+
+ND = NormalDist()
+Z10 = 1.2815515655446004                 # z for 90th/10th pct
+P_WITHIN_1SD = 0.6826894921370859        # P(|Z|<=1) for N(0,1)
+
+# Safety clamps
+MIN_CONSISTENCY, MAX_CONSISTENCY = 0.10, 0.95
+MIN_TAIL, MAX_TAIL = 0.02, 0.48
+MIN_SIGMA_POINTS, MAX_SIGMA_MULT = 0.5, 3.0
+
+def _to_float(x) -> Optional[float]:
+    try:
+        if x is None: return None
+        s = str(x).strip()
+        if s == "": return None
+        return float(s)
+    except Exception:
+        return None
+
+def _prob01(x: Optional[float]) -> Optional[float]:
+    p = _to_float(x)
+    if p is None: return None
+    if p > 1.0: p = p / 100.0
+    return max(1e-6, min(1.0 - 1e-6, p))
+
+def _clip(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+def estimate_sigma_base_points(
+    mean_fpts: float,
+    position: str,
+    default_qb_var: float,
+    default_skill_var: float,
+    default_def_var: float,
+    ceiling: Optional[float] = None,
+    floor: Optional[float] = None,
+) -> float:
+    pos = (position or "").upper()
+    m = float(mean_fpts)
+    c = _to_float(ceiling)
+    f = _to_float(floor)
+
+    sigma = None
+    if c is not None and f is not None and c > f:
+        sigma = (c - f) / (2.0 * Z10)
+    elif c is not None:
+        sigma = abs(c - m) / Z10
+    elif f is not None:
+        sigma = abs(m - f) / Z10
+    else:
+        if pos == "QB":
+            sigma = m * float(default_qb_var)
+        elif pos == "DST":
+            sigma = m * float(default_def_var)
+        else:
+            sigma = m * float(default_skill_var)
+
+    sigma = max(float(MIN_SIGMA_POINTS), float(sigma))
+    if sigma > MAX_SIGMA_MULT * max(1.0, m):
+        sigma = MAX_SIGMA_MULT * max(1.0, m)
+    return float(sigma)
+
+def consistency_factor(consistency_raw: Optional[float], beta: float = 1.0) -> float:
+    c = _prob01(consistency_raw)
+    if c is None: return 1.0
+    c = _clip(c, MIN_CONSISTENCY, MAX_CONSISTENCY)
+    factor = (P_WITHIN_1SD / c) ** float(beta)
+    return _clip(factor, 0.6, 1.6)
+
+def _inv_phi(p: float) -> float:
+    return ND.inv_cdf(p)
+
+def calibrate_sign_scales_from_tails(
+    upside_raw: Optional[float],
+    duds_raw: Optional[float],
+) -> Tuple[float, float]:
+    up = _prob01(upside_raw)
+    dn = _prob01(duds_raw)
+
+    if up is None and dn is None:
+        return 1.0, 1.0
+
+    if up is not None:
+        up = _clip(up, MIN_TAIL, MAX_TAIL)
+        r_plus = 0.5 / _inv_phi(1.0 - up)
+        r_plus = _clip(r_plus, 0.5, 2.0)
+    else:
+        r_plus = 1.0
+
+    if dn is not None:
+        dn = _clip(dn, MIN_TAIL, MAX_TAIL)
+        r_minus = 0.5 / _inv_phi(1.0 - dn)
+        r_minus = _clip(r_minus, 0.5, 2.0)
+    else:
+        r_minus = 1.0
+
+    return float(r_plus), float(r_minus)
+
+def sigma_effective_from_sign_scales(sigma_base: float, r_plus: float, r_minus: float) -> float:
+    return float(sigma_base * math.sqrt(0.5 * (r_plus * r_plus + r_minus * r_minus)))
+
+def build_player_risk(
+    *,
+    mean_fpts: float,
+    position: str,
+    default_qb_var: float,
+    default_skill_var: float,
+    default_def_var: float,
+    ceiling: Optional[float] = None,
+    floor: Optional[float] = None,
+    consistency_raw: Optional[float] = None,
+    upside_raw: Optional[float] = None,
+    duds_raw: Optional[float] = None,
+    beta_consistency: float = 1.0,
+) -> Dict[str, float]:
+    sigma_base = estimate_sigma_base_points(
+        mean_fpts=mean_fpts,
+        position=position,
+        default_qb_var=default_qb_var,
+        default_skill_var=default_skill_var,
+        default_def_var=default_def_var,
+        ceiling=ceiling,
+        floor=floor,
+    )
+    c_factor = consistency_factor(consistency_raw, beta=beta_consistency)
+    sigma_base_c = float(sigma_base * c_factor)
+    r_plus, r_minus = calibrate_sign_scales_from_tails(upside_raw=upside_raw, duds_raw=duds_raw)
+    sigma_eff = sigma_effective_from_sign_scales(sigma_base_c, r_plus, r_minus)
+    return {"sigma_base": sigma_base_c, "r_plus": r_plus, "r_minus": r_minus, "sigma_eff": sigma_eff}
+
+def draw_optimizer_noise_points(
+    rng: np.random.Generator,
+    randomness_pct: float,
+    sigma_base: float,
+    r_plus: float,
+    r_minus: float,
+) -> float:
+    if randomness_pct <= 0:
+        return 0.0
+    z = rng.standard_normal()
+    r_side = r_plus if z >= 0.0 else r_minus
+    return float(z * sigma_base * r_side * (randomness_pct / 100.0))
+
+def build_covariance_from_corr(
+    means: Sequence[float],
+    risks: Sequence[Dict[str, float]],
+    corr: np.ndarray,
+) -> np.ndarray:
+    n = len(means)
+    assert corr.shape == (n, n), "corr must be NxN"
+    sig = np.array([r["sigma_eff"] for r in risks], dtype=float)
+    return corr * np.outer(sig, sig)
+
+def sample_skewed_outcomes(
+    rng: np.random.Generator,
+    means: Sequence[float],
+    risks: Sequence[Dict[str, float]],
+    corr: np.ndarray,
+) -> np.ndarray:
+    n = len(means)
+    means = np.asarray(means, dtype=float)
+
+    # Make correlation PSD & unit-diagonal
+    try:
+        L = np.linalg.cholesky(corr)
+    except np.linalg.LinAlgError:
+        w, V = np.linalg.eigh(corr)
+        w = np.clip(w, 0.0, None)
+        corr_psd = (V @ np.diag(w) @ V.T)
+        d = np.sqrt(np.clip(np.diag(corr_psd), 1e-12, None))
+        corr = corr_psd / np.outer(d, d)
+        L = np.linalg.cholesky(corr + 1e-10 * np.eye(n))
+
+    z = rng.standard_normal(size=n)
+    z = L @ z
+
+    out = np.empty(n, dtype=float)
+    for i, zi in enumerate(z):
+        rb = risks[i]
+        r_side = rb["r_plus"] if zi >= 0.0 else rb["r_minus"]
+        shock = zi * rb["sigma_base"] * r_side
+        out[i] = means[i] + shock
+
+    return out


### PR DESCRIPTION
## Summary
- add risk_model module translating consistency/upside/duds into skew-aware sigma values
- adopt risk model in classic and showdown optimizers with sign-aware randomness
- update simulators to sample skewed outcomes respecting correlations

## Testing
- `PYTHONPATH=. pytest` *(fails: ValueError: Columns must..., TypeError: RandomAgent.act() takes 2 pos..., run_tournament() got an unexpected keyword ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f0c041088330a9440e8f36b479f9