### PR TITLE
Add optimizer and simulator jitter audit with selection and UI

### DIFF
--- a/src/_bootstrap_path.py
+++ b/src/_bootstrap_path.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+# Ensure the project root (one level above this file) is on sys.path
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.abspath(os.path.join(BASE_DIR, ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)

--- a/src/main.py
+++ b/src/main.py
@@ -63,11 +63,11 @@ with st.form("optimize"):
     submitted_opt = st.form_submit_button("Run Optimizer")
     if submitted_opt:
         if mode_opt == "showdown":
-            opto = NFL_Showdown_Optimizer(site_opt, num_lineups, num_uniques)
+            optimizer = NFL_Showdown_Optimizer(site_opt, num_lineups, num_uniques)
         else:
-            opto = NFL_Optimizer(site_opt, num_lineups, num_uniques)
-        opto.optimize()
-        lineup_path, stack_path = opto.output()
+            optimizer = NFL_Optimizer(site_opt, num_lineups, num_uniques)
+        optimizer.optimize()
+        lineup_path, stack_path = optimizer.output()
         if save_lineups:
             dest_dir = os.path.join(UPLOAD_DIR, site_opt)
             os.makedirs(dest_dir, exist_ok=True)
@@ -79,6 +79,15 @@ with st.form("optimize"):
             stack_df = pd.read_csv(stack_path)
             st.subheader("Stack Exposure")
             st.dataframe(stack_df)
+        try:
+            if hasattr(optimizer, "risk_table_df") and optimizer.risk_table_df is not None and not optimizer.risk_table_df.empty:
+                st.subheader("Risk Audit (Optimizer)")
+                st.dataframe(optimizer.risk_table_df, use_container_width=True, height=350)
+            if hasattr(optimizer, "jitter_table_df") and optimizer.jitter_table_df is not None and not optimizer.jitter_table_df.empty:
+                st.subheader("Jitter + Selection Audit (Optimizer)")
+                st.dataframe(optimizer.jitter_table_df, use_container_width=True, height=350)
+        except Exception:
+            pass
 
 # Simulation section
 st.header("Simulate Tournament")
@@ -116,3 +125,12 @@ with st.form("simulate"):
             stack_df = pd.read_csv(stack_path)
             st.subheader("Stack Exposure")
             st.dataframe(stack_df)
+        try:
+            if hasattr(sim, "risk_table_df") and sim.risk_table_df is not None and not sim.risk_table_df.empty:
+                st.subheader("Risk Audit (Simulator)")
+                st.dataframe(sim.risk_table_df, use_container_width=True, height=350)
+            if hasattr(sim, "jitter_table_df") and sim.jitter_table_df is not None and not sim.jitter_table_df.empty:
+                st.subheader("Jitter + Selection Audit (Simulator)")
+                st.dataframe(sim.jitter_table_df, use_container_width=True, height=350)
+        except Exception:
+            pass

--- a/src/nfl_gpp_simulator.py
+++ b/src/nfl_gpp_simulator.py
@@ -79,6 +79,7 @@ import numpy as np
 import pulp as plp
 import multiprocessing as mp
 from risk_model import build_player_risk, build_covariance_from_corr, sample_skewed_outcomes
+from risk_audit import RiskAuditAccumulator
 import pandas as pd
 import statistics
 
@@ -203,6 +204,12 @@ class NFL_GPP_Simulator:
         self.pool_factor = pool_factor
         self.targets = {}
         self.stack_exposure_df = None
+
+        self.output_dir = os.path.join(os.path.dirname(__file__), "..", "output")
+        self._audit = RiskAuditAccumulator(output_dir=self.output_dir)
+        self.risk_table_df = None
+        self.jitter_table_df = None
+        self._players_by_id = {}
 
         self.load_config()
         self.load_rules()
@@ -833,7 +840,10 @@ class NFL_GPP_Simulator:
                 pid_team = dst_id_by_team(self._player_ids_df, team)
                 if pid_team:
                     rec["ID"] = str(pid_team)
-
+        for rec in self.player_dict.values():
+            pid = rec.get("ID")
+            if pid:
+                self._players_by_id[pid] = rec
         return df
 
     def load_contest_data(self, path):
@@ -1086,6 +1096,22 @@ class NFL_GPP_Simulator:
                         team = "JAC"
                     if opp == "JAX":
                         opp = "JAC"
+
+                self._audit.add_risk_row(
+                    name=str(row.get("name") or row.get("Name") or player_name),
+                    pos=pos,
+                    team=team,
+                    proj=fpts,
+                    floor=(row.get("projections_floor") or row.get("floor")),
+                    ceiling=(row.get("projections_ceiling") or row.get("ceiling")),
+                    consistency=row.get("fantasyyear_consistency"),
+                    upside=row.get("fantasyyear_upside"),
+                    duds=row.get("fantasyyear_duds"),
+                    sigma_base=sigma_base,
+                    sigma_eff=stddev,
+                    r_plus=r_plus,
+                    r_minus=r_minus,
+                )
 
                 # Build matchup identifiers that are consistent for both teams
                 if opp:
@@ -2729,6 +2755,39 @@ class NFL_GPP_Simulator:
         # ranks = np.argsort(fpts_array, axis=0)[::-1].astype(np.uint16)
         ranks = np.argsort(-fpts_array, axis=0).astype(np.uint32)
 
+        try:
+            player_info_by_id = {rec["ID"]: rec for rec in self.player_dict.values() if rec.get("ID")}
+            index_to_key = list(self.field_lineups.keys())
+            lineup_players = {idx: self.field_lineups[idx]["Lineup"] for idx in index_to_key}
+            noise_by_id = {}
+            for pid, samples in temp_fpts_dict.items():
+                rec = player_info_by_id.get(pid)
+                if rec is None:
+                    continue
+                proj = rec.get("fieldFpts") or rec.get("Fpts")
+                noise_by_id[pid] = np.array(samples) - float(proj or 0)
+            for sim_idx in range(self.num_iterations):
+                self._audit.start_iteration()
+                selected_lineup_idx = ranks[0, sim_idx]
+                selected_ids = lineup_players.get(index_to_key[selected_lineup_idx], [])
+                for pid, noise_arr in noise_by_id.items():
+                    rec = player_info_by_id.get(pid)
+                    self._audit.record_jitter_sample(
+                        player_id=pid,
+                        name=rec.get("Name"),
+                        pos=_canon_pos_primary(rec.get("Position")),
+                        team=rec.get("Team"),
+                        proj=rec.get("fieldFpts") or rec.get("Fpts"),
+                        sigma_base=rec.get("SigmaBase"),
+                        sigma_eff=rec.get("StdDev"),
+                        r_plus=rec.get("RPlus"),
+                        r_minus=rec.get("RMinus"),
+                        noise_points=float(noise_arr[sim_idx]),
+                    )
+                self._audit.finalize_iteration(selected_ids)
+        except Exception:
+            pass
+
         # count wins, top 10s vectorized
         wins, win_counts = np.unique(ranks[0, :], return_counts=True)
         cashes, cash_counts = np.unique(ranks[0:len(list(self.payout_structure.values()))], return_counts=True)
@@ -2790,6 +2849,15 @@ class NFL_GPP_Simulator:
                 ][0]
             if idx in cashes:
                 self.field_lineups[idx]["Cashes"] += cash_counts[np.where(cashes == idx)][0]
+        try:
+            if self._audit:
+                self._audit.output_dir = self.output_dir
+                self.risk_table_df = self._audit.build_risk_table()
+                self.jitter_table_df = self._audit.build_jitter_table()
+                self._audit.save_risk_table("risk_table_simulator.csv")
+                self._audit.save_jitter_table("risk_jitter_simulator.csv")
+        except Exception:
+            pass
 
         end_time = time.time()
         diff = end_time - start_time

--- a/src/nfl_showdown_simulator.py
+++ b/src/nfl_showdown_simulator.py
@@ -16,6 +16,7 @@ import collections
 import re
 from scipy.stats import norm, kendalltau, gamma
 from risk_model import build_player_risk, sample_skewed_outcomes
+from risk_audit import RiskAuditAccumulator
 import matplotlib.pyplot as plt
 import seaborn as sns
 from numba import njit, jit
@@ -62,6 +63,12 @@ class NFL_Showdown_Simulator:
         self.max_pct_off_optimal = 0.4
         self.teams_dict = collections.defaultdict(list)
         self.correlation_rules = {}
+
+        self.output_dir = os.path.join(os.path.dirname(__file__), "..", "output")
+        self._audit = RiskAuditAccumulator(output_dir=self.output_dir)
+        self.risk_table_df = None
+        self.jitter_table_df = None
+        self._players_by_id = {}
 
         self.load_config()
         self.load_rules()
@@ -364,6 +371,10 @@ class NFL_Showdown_Simulator:
                                 continue
                             break
                     self.id_name_dict[str(row.get("id", ""))] = row.get("nickname") or row.get("displayname", "")
+        for rec in self.player_dict.values():
+            pid = rec.get("ID")
+            if pid:
+                self._players_by_id[pid] = rec
 
     def load_correlation_rules(self):
         if len(self.correlation_rules.keys()) > 0:
@@ -630,6 +641,21 @@ class NFL_Showdown_Simulator:
                 if self.site == "fd":
                     if team == "JAX":
                         team = "JAC"
+                self._audit.add_risk_row(
+                    name=str(row.get("name") or row.get("Name") or player_name),
+                    pos=pos,
+                    team=team,
+                    proj=fpts,
+                    floor=(row.get("projections_floor") or row.get("floor")),
+                    ceiling=(row.get("projections_ceiling") or row.get("ceiling")),
+                    consistency=row.get("fantasyyear_consistency"),
+                    upside=row.get("fantasyyear_upside"),
+                    duds=row.get("fantasyyear_duds"),
+                    sigma_base=sigma_base,
+                    sigma_eff=stddev,
+                    r_plus=r_plus,
+                    r_minus=r_minus,
+                )
                 if team not in self.team_list:
                     self.team_list.append(team)
                 own = float(row["projections_projown"]) if row["projections_projown"] != "" else 0
@@ -1433,6 +1459,42 @@ class NFL_Showdown_Simulator:
         # ranks = np.argsort(fpts_array, axis=0)[::-1].astype(np.uint16)
         ranks = np.argsort(-fpts_array, axis=0).astype(np.uint32)
 
+        try:
+            player_info_by_id = {rec["ID"]: rec for rec in self.player_dict.values() if rec.get("ID")}
+            index_to_key = list(self.field_lineups.keys())
+            lineup_players = {idx: self.field_lineups[idx]["Lineup"]["Lineup"] for idx in index_to_key}
+            noise_by_id = {}
+            for pid, samples in temp_fpts_dict.items():
+                rec = player_info_by_id.get(pid)
+                if rec is None:
+                    continue
+                proj = rec.get("fieldFpts") or rec.get("Fpts")
+                noise_by_id[pid] = np.array(samples) - float(proj or 0)
+            for sim_idx in range(self.num_iterations):
+                self._audit.start_iteration()
+                selected_lineup_idx = ranks[0, sim_idx]
+                selected_ids = lineup_players.get(index_to_key[selected_lineup_idx], [])
+                for pid, noise_arr in noise_by_id.items():
+                    rec = player_info_by_id.get(pid)
+                    pos_val = rec.get("Position")
+                    if isinstance(pos_val, list):
+                        pos_val = pos_val[0] if pos_val else ""
+                    self._audit.record_jitter_sample(
+                        player_id=pid,
+                        name=rec.get("Name"),
+                        pos=pos_val,
+                        team=rec.get("Team"),
+                        proj=rec.get("fieldFpts") or rec.get("Fpts"),
+                        sigma_base=rec.get("SigmaBase"),
+                        sigma_eff=rec.get("StdDev"),
+                        r_plus=rec.get("RPlus"),
+                        r_minus=rec.get("RMinus"),
+                        noise_points=float(noise_arr[sim_idx]),
+                    )
+                self._audit.finalize_iteration(selected_ids)
+        except Exception:
+            pass
+
         # count wins, top 10s vectorized
         wins, win_counts = np.unique(ranks[0, :], return_counts=True)
         t10, t10_counts = np.unique(ranks[0:9], return_counts=True)
@@ -1488,6 +1550,15 @@ class NFL_Showdown_Simulator:
                 self.field_lineups[idx]["Lineup"]["Top10"] += t10_counts[
                     np.where(t10 == idx)
                 ][0]
+        try:
+            if self._audit:
+                self._audit.output_dir = self.output_dir
+                self.risk_table_df = self._audit.build_risk_table()
+                self.jitter_table_df = self._audit.build_jitter_table()
+                self._audit.save_risk_table("risk_table_simulator.csv")
+                self._audit.save_jitter_table("risk_jitter_simulator.csv")
+        except Exception:
+            pass
 
         end_time = time.time()
         diff = end_time - start_time

--- a/src/pages/98_Risk_Audit.py
+++ b/src/pages/98_Risk_Audit.py
@@ -1,0 +1,179 @@
+import _bootstrap_path  # ensure project root is on sys.path
+
+import os
+import time
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="Risk & Jitter Audit", layout="wide")
+
+st.title("Risk Audit — Consistency / Upside / Duds")
+st.caption("Confirms risk inputs and derived σ & skew used by the Optimizer/Simulator.")
+
+st.markdown("---")
+
+st.header("Risk Table")
+
+def _find_existing(paths):
+    return [p for p in paths if p and os.path.exists(p)]
+
+def _latest(paths):
+    xs = _find_existing(paths)
+    return max(xs, key=lambda p: os.path.getmtime(p)) if xs else None
+
+# Candidate default locations
+CAND_RISK = [
+    os.path.join("outputs", "risk_table_optimizer.csv"),
+    os.path.join("outputs", "risk_table_simulator.csv"),
+    os.path.join("risk_table_optimizer.csv"),
+    os.path.join("risk_table_simulator.csv"),
+]
+CAND_JITTER = [
+    os.path.join("outputs", "risk_jitter_optimizer.csv"),
+    os.path.join("risk_jitter_optimizer.csv"),
+    os.path.join("outputs", "risk_jitter_simulator.csv"),
+    os.path.join("risk_jitter_simulator.csv"),
+]
+
+with st.expander("Data sources", expanded=True):
+    # Risk
+    risk_auto = _latest(CAND_RISK)
+    risk_choice = st.radio("Risk table", ["Auto-detect latest", "Pick file..."], horizontal=True, key="risk_src")
+    risk_path = risk_auto if risk_choice == "Auto-detect latest" else st.text_input("Path to risk_table CSV", value=risk_auto or "", key="risk_path")
+
+    # Jitter
+    jitter_auto = _latest(CAND_JITTER)
+    jitter_choice = st.radio("Jitter table", ["Auto-detect latest", "Pick file..."], horizontal=True, key="jitter_src")
+    jitter_path = jitter_auto if jitter_choice == "Auto-detect latest" else st.text_input("Path to risk_jitter CSV", value=jitter_auto or "", key="jitter_path")
+
+# ----- Risk table -----
+if risk_path and os.path.exists(risk_path):
+    rdf = pd.read_csv(risk_path)
+
+    cols = st.columns([1, 1, 2, 2])
+    with cols[0]:
+        pos_filter = st.multiselect("Position", sorted([p for p in rdf["pos"].dropna().unique() if isinstance(p, str)]))
+    with cols[1]:
+        team_filter = st.multiselect("Team", sorted([t for t in rdf["team"].dropna().unique() if isinstance(t, str)]))
+    with cols[2]:
+        name_search = st.text_input("Name contains", "", key="risk_name")
+    with cols[3]:
+        sort_by = st.selectbox("Sort by", ["pos","team","name","proj","sigma_eff","r_plus","r_minus"], key="risk_sort")
+
+    q = rdf.copy()
+    if pos_filter: q = q[q["pos"].isin(pos_filter)]
+    if team_filter: q = q[q["team"].isin(team_filter)]
+    if name_search.strip():
+        s = name_search.strip().lower()
+        q = q[q["name"].str.lower().str.contains(s, na=False)]
+    q = q.sort_values(sort_by, kind="stable").reset_index(drop=True)
+
+    def _fmt_percent_auto(x):
+        try:
+            x = float(x)
+        except Exception:
+            return x
+        if 0.0 <= x <= 1.0:
+            return f"{x*100:.1f}%"
+        return f"{x:.1f}"
+
+    show_cols = ["name","pos","team","proj","floor","ceiling","consistency","upside","duds","sigma_base","sigma_eff","sigma_shrink_factor","r_plus","r_minus"]
+    show_cols = [c for c in show_cols if c in q.columns]
+
+    st.dataframe(
+        q[show_cols].style.format({
+            "proj": "{:.2f}",
+            "floor": "{:.2f}",
+            "ceiling": "{:.2f}",
+            "sigma_base": "{:.3f}",
+            "sigma_eff": "{:.3f}",
+            "sigma_shrink_factor": "{:.3f}",
+            "r_plus": "{:.3f}",
+            "r_minus": "{:.3f}",
+            "consistency": _fmt_percent_auto,
+            "upside": _fmt_percent_auto,
+            "duds": _fmt_percent_auto,
+        }),
+        use_container_width=True,
+        height=420,
+    )
+
+    st.download_button(
+        "Download Risk CSV",
+        data=q.to_csv(index=False).encode("utf-8"),
+        file_name=os.path.basename(risk_path).replace(".csv", "_filtered.csv"),
+        mime="text/csv",
+        key="dl_risk",
+    )
+else:
+    st.info("No risk table found yet. Run the optimizer or simulator first.")
+
+st.markdown("---")
+st.header("Jitter + Selection Table")
+
+if jitter_path and os.path.exists(jitter_path):
+    jdf = pd.read_csv(jitter_path)
+
+    cols2 = st.columns([1, 1, 2, 2])
+    with cols2[0]:
+        pos_filter_j = st.multiselect("Position", sorted([p for p in jdf["pos"].dropna().unique() if isinstance(p, str)]), key="jit_pos")
+    with cols2[1]:
+        team_filter_j = st.multiselect("Team", sorted([t for t in jdf["team"].dropna().unique() if isinstance(t, str)]), key="jit_team")
+    with cols2[2]:
+        name_search_j = st.text_input("Name contains", "", key="jit_name")
+    with cols2[3]:
+        sort_by_j = st.selectbox(
+            "Sort by",
+            ["pos","team","name","nudged_total","selection_rate","selected_when_up_rate","selected_when_down_rate","avg_nudge_pts","avg_abs_nudge_pts"],
+            key="jit_sort"
+        )
+
+    qj = jdf.copy()
+    if pos_filter_j: qj = qj[qj["pos"].isin(pos_filter_j)]
+    if team_filter_j: qj = qj[qj["team"].isin(team_filter_j)]
+    if name_search_j.strip():
+        s = name_search_j.strip().lower()
+        qj = qj[qj["name"].str.lower().str.contains(s, na=False)]
+    qj = qj.sort_values(sort_by_j, kind="stable").reset_index(drop=True)
+
+    show_cols_j = [
+        "name","pos","team","proj",
+        "sigma_base","sigma_eff","r_plus","r_minus",
+        "nudged_up","nudged_down","nudged_total",
+        "nudged_up_selected","nudged_up_not_selected",
+        "nudged_down_selected","nudged_down_not_selected",
+        "selected_total","selection_rate",
+        "selected_when_up_rate","selected_when_down_rate",
+        "avg_nudge_pts","avg_abs_nudge_pts",
+        "avg_nudge_pts_selected","avg_abs_nudge_pts_selected",
+    ]
+    show_cols_j = [c for c in show_cols_j if c in qj.columns]
+
+    st.dataframe(
+        qj[show_cols_j].style.format({
+            "proj": "{:.2f}",
+            "sigma_base": "{:.3f}",
+            "sigma_eff": "{:.3f}",
+            "r_plus": "{:.3f}",
+            "r_minus": "{:.3f}",
+            "selection_rate": "{:.1%}",
+            "selected_when_up_rate": "{:.1%}",
+            "selected_when_down_rate": "{:.1%}",
+            "avg_nudge_pts": "{:.4f}",
+            "avg_abs_nudge_pts": "{:.4f}",
+            "avg_nudge_pts_selected": "{:.4f}",
+            "avg_abs_nudge_pts_selected": "{:.4f}",
+        }),
+        use_container_width=True,
+        height=480,
+    )
+
+    st.download_button(
+        "Download Jitter+Selection CSV",
+        data=qj.to_csv(index=False).encode("utf-8"),
+        file_name=os.path.basename(jitter_path).replace(".csv", "_filtered.csv"),
+        mime="text/csv",
+        key="dl_jitter",
+    )
+else:
+    st.info("No jitter/selection table found yet. Run the optimizer or simulator (they write this).")

--- a/src/risk_audit.py
+++ b/src/risk_audit.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+risk_audit.py
+
+Provides:
+1) Risk table (shared by Optimizer & Simulator):
+   - Inputs: fantasyyear_consistency, fantasyyear_upside, fantasyyear_duds
+   - Derived: sigma_base, sigma_eff, r_plus, r_minus (+ shrink factor)
+   - Context: name, pos, team, proj, floor, ceiling
+
+2) Optimizer jitter audit WITH selection impact:
+   - Tracks, per player (ID), across lineup-build iterations:
+       nudged_up, nudged_down, nudged_total
+       nudged_up_selected, nudged_up_not_selected
+       nudged_down_selected, nudged_down_not_selected
+       selected_total, selection_rate
+       selected_when_up_rate, selected_when_down_rate
+       avg_nudge_pts (signed), avg_abs_nudge_pts
+       avg_nudge_pts_selected, avg_abs_nudge_pts_selected
+   - Uses a per-iteration staging buffer so we can join the jitter sign with
+     the solve result (selected vs not).
+
+Outputs written by callers:
+  - risk_table_optimizer.csv / risk_table_simulator.csv
+  - risk_jitter_optimizer.csv / risk_jitter_simulator.csv
+"""
+
+from typing import Dict, List, Optional, Iterable, Union
+import os
+import pandas as pd
+
+# ---------- Utilities ----------
+
+def _to_float(x):
+    try:
+        if x is None: return None
+        s = str(x).strip()
+        if s == "": return None
+        return float(s)
+    except Exception:
+        return None
+
+def _ensure_dir(d: Optional[str]) -> str:
+    if not d:
+        return "."
+    try:
+        os.makedirs(d, exist_ok=True)
+    except Exception:
+        pass
+    return d
+
+# ---------- Risk table (shared) ----------
+
+RISK_NUM_COLS = [
+    "proj","floor","ceiling","consistency","upside","duds",
+    "sigma_base","sigma_eff","r_plus","r_minus","sigma_shrink_factor",
+]
+
+RISK_DISPLAY_ORDER = [
+    "name","pos","team",
+    "proj","floor","ceiling",
+    "consistency","upside","duds",
+    "sigma_base","sigma_eff","sigma_shrink_factor",
+    "r_plus","r_minus",
+]
+
+# ---------- Jitter table (optimizer) ----------
+
+JITTER_DISPLAY_ORDER = [
+    "name","pos","team","proj",
+    "sigma_base","sigma_eff","r_plus","r_minus",
+    "nudged_up","nudged_down","nudged_total",
+    "nudged_up_selected","nudged_up_not_selected",
+    "nudged_down_selected","nudged_down_not_selected",
+    "selected_total","selection_rate",
+    "selected_when_up_rate","selected_when_down_rate",
+    "avg_nudge_pts","avg_abs_nudge_pts",
+    "avg_nudge_pts_selected","avg_abs_nudge_pts_selected",
+]
+
+class RiskAuditAccumulator:
+    """
+    Accumulates:
+      - Risk rows (shared)
+      - Optimizer jitter rows WITH selection impact
+
+    Keys jitter by unique player_id to avoid name collisions.
+    """
+
+    def __init__(self, output_dir: Optional[str] = None):
+        self.output_dir = output_dir
+
+        # Risk rows (simple list of dicts)
+        self._risk_rows: List[Dict] = []
+
+        # Jitter persistent store: player_id -> dict of aggregates
+        self._jitter: Dict[Union[int,str], Dict] = {}
+
+        # Per-iteration staging: player_id -> last noise (points)
+        self._iter_noise: Dict[Union[int,str], float] = {}
+
+    # ----- Risk rows -----
+
+    def add_risk_row(self, *,
+                     name: str,
+                     pos: str,
+                     team: str,
+                     proj: float,
+                     floor: Optional[float],
+                     ceiling: Optional[float],
+                     consistency: Optional[float],
+                     upside: Optional[float],
+                     duds: Optional[float],
+                     sigma_base: float,
+                     sigma_eff: float,
+                     r_plus: float,
+                     r_minus: float) -> None:
+        self._risk_rows.append({
+            "name": name,
+            "pos": (pos or "").upper(),
+            "team": team,
+            "proj": _to_float(proj),
+            "floor": _to_float(floor),
+            "ceiling": _to_float(ceiling),
+            "consistency": _to_float(consistency),  # may be 0..1 or 0..100; shown as-is
+            "upside": _to_float(upside),
+            "duds": _to_float(duds),
+            "sigma_base": _to_float(sigma_base),
+            "sigma_eff": _to_float(sigma_eff),
+            "r_plus": _to_float(r_plus),
+            "r_minus": _to_float(r_minus),
+            "sigma_shrink_factor": (
+                (_to_float(sigma_eff) / _to_float(sigma_base))
+                if (_to_float(sigma_base) and _to_float(sigma_eff)) else None
+            ),
+        })
+
+    def build_risk_table(self) -> pd.DataFrame:
+        df = pd.DataFrame(self._risk_rows)
+        if df.empty:
+            return pd.DataFrame(columns=RISK_DISPLAY_ORDER)
+        for c in RISK_NUM_COLS:
+            if c in df.columns:
+                df[c] = pd.to_numeric(df[c], errors="coerce")
+        for c in ["name","pos","team"]:
+            if c not in df.columns:
+                df[c] = ""
+        df = df.sort_values(["pos","team","name"], kind="stable").reset_index(drop=True)
+        cols = [c for c in RISK_DISPLAY_ORDER if c in df.columns] + [c for c in df.columns if c not in RISK_DISPLAY_ORDER]
+        return df[cols]
+
+    def save_risk_table(self, filename: str) -> Optional[str]:
+        df = self.build_risk_table()
+        if df.empty: return None
+        out_dir = _ensure_dir(self.output_dir)
+        path = os.path.join(out_dir, filename)
+        try:
+            df.to_csv(path, index=False)
+            return path
+        except Exception:
+            return None
+
+    # ----- Optimizer jitter with selection -----
+
+    def start_iteration(self) -> None:
+        """Call at the start of a lineup build iteration (before drawing jitter)."""
+        self._iter_noise = {}
+
+    def record_jitter_sample(self, *,
+                             player_id: Union[int,str],
+                             name: str,
+                             pos: str,
+                             team: str,
+                             proj: Optional[float],
+                             sigma_base: Optional[float],
+                             sigma_eff: Optional[float],
+                             r_plus: Optional[float],
+                             r_minus: Optional[float],
+                             noise_points: float) -> None:
+        """
+        Record the jitter draw for this iteration. Selection impact is joined later.
+        """
+        pid = player_id
+        # Stage noise so we can join with selection after solve:
+        self._iter_noise[pid] = float(noise_points)
+
+        # Ensure persistent entry exists and carries reference fields
+        ent = self._jitter.get(pid)
+        if ent is None:
+            ent = {
+                "player_id": pid,
+                "name": str(name),
+                "pos": (pos or "").upper(),
+                "team": str(team),
+                "proj": _to_float(proj),
+                "sigma_base": _to_float(sigma_base),
+                "sigma_eff": _to_float(sigma_eff),
+                "r_plus": _to_float(r_plus),
+                "r_minus": _to_float(r_minus),
+
+                # counts
+                "nudged_up": 0,
+                "nudged_down": 0,
+                "nudged_total": 0,
+                "nudged_up_selected": 0,
+                "nudged_up_not_selected": 0,
+                "nudged_down_selected": 0,
+                "nudged_down_not_selected": 0,
+                "selected_total": 0,
+
+                # sums for averages
+                "sum_nudge": 0.0,
+                "sum_abs_nudge": 0.0,
+                "sum_nudge_selected": 0.0,
+                "sum_abs_nudge_selected": 0.0,
+            }
+            self._jitter[pid] = ent
+
+    def finalize_iteration(self, selected_player_ids: Iterable[Union[int,str]]) -> None:
+        """
+        Call AFTER solving one lineup. Joins staged noise with selection.
+        `selected_player_ids` is the set/list of IDs included in the solved lineup.
+        """
+        sel = set(selected_player_ids or [])
+        for pid, noise in self._iter_noise.items():
+            ent = self._jitter.get(pid)
+            if ent is None:
+                # Shouldn't happen; guard anyway
+                continue
+
+            is_up = noise >= 0.0
+            was_selected = pid in sel
+
+            # Counts
+            if is_up:
+                ent["nudged_up"] += 1
+                if was_selected:
+                    ent["nudged_up_selected"] += 1
+                else:
+                    ent["nudged_up_not_selected"] += 1
+            else:
+                ent["nudged_down"] += 1
+                if was_selected:
+                    ent["nudged_down_selected"] += 1
+                else:
+                    ent["nudged_down_not_selected"] += 1
+
+            ent["nudged_total"] += 1
+            if was_selected:
+                ent["selected_total"] += 1
+
+            # Sums for averages
+            ent["sum_nudge"] += float(noise)
+            ent["sum_abs_nudge"] += abs(float(noise))
+            if was_selected:
+                ent["sum_nudge_selected"] += float(noise)
+                ent["sum_abs_nudge_selected"] += abs(float(noise))
+
+        # Clear staging for next iteration
+        self._iter_noise = {}
+
+    def build_jitter_table(self) -> pd.DataFrame:
+        if not self._jitter:
+            return pd.DataFrame(columns=JITTER_DISPLAY_ORDER)
+        df = pd.DataFrame(list(self._jitter.values()))
+        if df.empty:
+            return pd.DataFrame(columns=JITTER_DISPLAY_ORDER)
+
+        # Averages & rates
+        with pd.option_context('mode.use_inf_as_na', True):
+            tot = df["nudged_total"].replace({0: pd.NA})
+            up  = df["nudged_up"].replace({0: pd.NA})
+            dn  = df["nudged_down"].replace({0: pd.NA})
+
+            df["avg_nudge_pts"] = df["sum_nudge"] / tot
+            df["avg_abs_nudge_pts"] = df["sum_abs_nudge"] / tot
+
+            df["avg_nudge_pts_selected"] = df["sum_nudge_selected"] / df["selected_total"].replace({0: pd.NA})
+            df["avg_abs_nudge_pts_selected"] = df["sum_abs_nudge_selected"] / df["selected_total"].replace({0: pd.NA})
+
+            df["selection_rate"] = df["selected_total"] / df["nudged_total"].replace({0: pd.NA})
+            df["selected_when_up_rate"] = df["nudged_up_selected"] / up
+            df["selected_when_down_rate"] = df["nudged_down_selected"] / dn
+
+        # Cleanup & order
+        drop_cols = ["sum_nudge","sum_abs_nudge","sum_nudge_selected","sum_abs_nudge_selected","player_id"]
+        df = df.drop(columns=[c for c in drop_cols if c in df.columns], errors="ignore")
+        df = df.sort_values(["pos","team","name"], kind="stable").reset_index(drop=True)
+        cols = [c for c in JITTER_DISPLAY_ORDER if c in df.columns] + [c for c in df.columns if c not in JITTER_DISPLAY_ORDER]
+        return df[cols]
+
+    def save_jitter_table(self, filename: str) -> Optional[str]:
+        df = self.build_jitter_table()
+        if df.empty: return None
+        out_dir = _ensure_dir(self.output_dir)
+        path = os.path.join(out_dir, filename)
+        try:
+            df.to_csv(path, index=False)
+            return path
+        except Exception:
+            return None


### PR DESCRIPTION
## Summary
- extend RiskAuditAccumulator to simulators, tracking per-iteration jitter and lineup selections
- save `risk_table_simulator.csv` and `risk_jitter_simulator.csv` and expose DataFrames in simulator
- update risk audit page and main UI to surface simulator audit tables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60f2aed8c8330ac41ed79d6729eb2