### PR TITLE
Add Streamlit download for full simulation lineups

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -115,10 +115,19 @@ with st.form("simulate"):
             sim.generate_field_lineups()
             sim.run_tournament_simulation()
             lineup_path, exposure_path, stack_path = sim.output()
-        lineup_df = pd.read_csv(lineup_path)
+        lineup_df = pd.read_csv(lineup_path, nrows=1000)
         exposure_df = pd.read_csv(exposure_path)
-        st.subheader("Lineups")
+        st.subheader("Lineups (showing first 1,000 entries)")
         st.dataframe(lineup_df)
+        if lineup_path and os.path.exists(lineup_path):
+            with open(lineup_path, "rb") as f:
+                lineup_csv = f.read()
+            st.download_button(
+                "Download full lineup CSV",
+                lineup_csv,
+                file_name=os.path.basename(lineup_path),
+                mime="text/csv",
+            )
         st.subheader("Exposure")
         st.dataframe(exposure_df)
         if stack_path:


### PR DESCRIPTION
## Summary
- limit the Streamlit tournament simulation lineup preview to the first 1,000 rows
- update the corresponding subheader text to clarify the truncated display while leaving exports untouched
- add a dedicated download button that serves the complete lineup CSV so exports aren't truncated by the preview

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd59158e308330afa1ecf5f53b0698