### PR TITLE
Ensure FLEX slot uses latest kickoff information

### DIFF
--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,9 +1,10 @@
 import sys
 import os
 import pytest
+import datetime
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", "src"))
-from nfl_optimizer import NFL_Optimizer
+from nfl_optimizer import NFL_Optimizer, Player
 
 
 def test_optimizer_handles_players_removed_from_player_dict():
@@ -53,3 +54,26 @@ def test_optimizer_skips_stack_when_opponent_missing():
 
     # Should not raise KeyError when opponent team is missing
     opt.optimize()
+
+
+def test_select_slot_players_promotes_latest_start():
+    opt = NFL_Optimizer(site="dk", num_lineups=0, num_uniques=1)
+
+    early = datetime.datetime(2025, 9, 21, 13, 0)
+    late = datetime.datetime(2025, 9, 21, 16, 25)
+
+    players = [
+        Player(name="QB", pos="QB", team="AAA", salary=7000, proj=20, start_time=early),
+        Player(name="RB1", pos="RB", team="AAA", salary=6800, proj=18, start_time=early),
+        Player(name="RB2", pos="RB", team="AAA", salary=6600, proj=17, start_time=early),
+        Player(name="WR Late", pos="WR", team="AAA", salary=7200, proj=19, start_time=late),
+        Player(name="WR2", pos="WR", team="AAA", salary=7100, proj=18, start_time=early),
+        Player(name="WR3", pos="WR", team="AAA", salary=7000, proj=17, start_time=early),
+        Player(name="WR Flex", pos="WR", team="AAA", salary=6900, proj=16, start_time=early),
+        Player(name="TE", pos="TE", team="AAA", salary=5000, proj=12, start_time=early),
+        Player(name="DST", pos="DST", team="AAA", salary=3000, proj=8, start_time=early),
+    ]
+
+    slots = opt.select_slot_players(players)
+    assert slots["FLEX"].name == "WR Late"
+    assert slots["WR1"].name == "WR Flex"


### PR DESCRIPTION
## Summary
- parse DraftKings Game Info to capture kickoff times when loading player data
- use stored start times to move the latest-eligible RB/WR/TE into the FLEX slot in the simulator, optimizer, and CSV writer
- add regression tests covering FLEX ordering and kickoff parsing helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d179ada2dc8330ad68cdab7111905c