### PR TITLE
Add portfolio diversity guards and wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,44 @@ Where:
 
 `<num_lineups>` is the number of lineups you want to generate when using the `opto` process.
 
+### Portfolio Diversity (Anti-Cannibalization)
+
+Large portfolio runs can now be filtered through a lightweight diversification pass to prevent the most common self-cannibalisation mistakes.
+
+- **Overlap guards:** enforce a maximum number of shared players between any pair of lineups and a minimum Jaccard distance.
+- **Exposure caps:** keep per-player and per-team exposure below configurable limits based on the requested portfolio size.
+- **Stack mix quotas:** optionally bound the share of key stack archetypes (e.g. `QB+WR`, `QB+WR+TE`, `No Stack`).
+- **Ownership-aware ordering:** when ownership data is available the selector prefers rarer combinations first.
+
+Run the wrappers from the project root:
+
+```bash
+python -m scripts.run_optimizer_diverse
+python -m scripts.run_simulator_with_diversity
+```
+
+The optimiser wrapper writes `output/optimized_lineups_diverse.csv` plus an audit at `output/diversity_audit.json`. The simulator wrapper reuses the same rules, writes `output/simulator_diverse_lineups.csv`, and drops `output/simulator_diversity_audit.json` alongside the standard simulator outputs.
+
+Configuration lives in the normal `config.json`. Add an optional `diversity` block to tune the guards (the values below match the defaults):
+
+```json
+"diversity": {
+  "pool_factor": 4,
+  "max_shared_players": 6,
+  "min_jaccard_distance": 0.20,
+  "per_player_cap": 0.45,
+  "per_team_cap": 0.40,
+  "min_stack_mix": {
+    "QB+WR": 0.30,
+    "QB+WR+TE": 0.15,
+    "No Stack": 0.10
+  },
+  "max_stack_mix": null
+}
+```
+
+The simulator wrapper honours `num_sim_lineups` from `config.json` (defaulting to the size of the filtered pool) so you can request fewer lineups than are available.
+
 `<num_uniques>` defines the number of players that must differ from one lineup to the next. These unique constraints are applied at the time of optimization, so if you ask for 10 lineups with 5 unique players, you will get 10 lineups with 5 unique players. In the past, this was enforced post-optimization, meaning it would prune lineups from the pool if they violated the unique constraints, resulting in fewer lineups than requested.
 
 For example, to generate 1000 lineups for DraftKings, with 3 uniques and randomness, I would execute the following:

--- a/scripts/run_optimizer_diverse.py
+++ b/scripts/run_optimizer_diverse.py
@@ -1,0 +1,256 @@
+"""Generate a diversified lineup portfolio using the existing optimiser."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from dataclasses import asdict
+from typing import Dict, Iterable, List, Optional
+
+from src.anti_cannibalizer import Candidate, DiversityRules, diversify_portfolio
+
+try:  # Optimiser class name varies between forks.
+    from src.nfl_optimizer import NFLClassicOptimizer as _Optimizer  # type: ignore
+except ImportError:  # pragma: no cover - fall back to legacy name
+    from src.nfl_optimizer import NFL_Optimizer as _Optimizer  # type: ignore
+
+try:
+    from src.stack_metrics import analyze_lineup
+except Exception:  # pragma: no cover - stack detection optional when metadata missing
+    analyze_lineup = None  # type: ignore
+
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+OUTPUT_DIR = os.path.join(ROOT_DIR, "output")
+CONFIG_PATHS = [
+    os.path.join(ROOT_DIR, "config.json"),
+    os.path.join(ROOT_DIR, "sample.config.json"),
+]
+
+
+def _load_config() -> Dict:
+    for path in CONFIG_PATHS:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+    return {}
+
+
+def _format_player(rec: Dict, site: str) -> str:
+    name = str(rec.get("Name") or rec.get("name") or rec.get("PlayerName") or "").strip()
+    pid = rec.get("ID") or rec.get("Id") or rec.get("PlayerID")
+    if pid in ("", 0, "0"):
+        pid = None
+    if pid is not None:
+        pid = str(pid).strip()
+    if not name:
+        name = pid or "Unknown"
+    if site.lower() == "dk":
+        return f"{name} ({pid})" if pid else name
+    if site.lower() == "fd":
+        return f"{pid}:{name}" if pid else name
+    return f"{name} ({pid})" if pid else name
+
+
+def _ownership(rec: Dict) -> Optional[float]:
+    for key in ("Own%", "Own", "Ownership", "ProjOwn", "ProjOwn%", "ProjectedOwn", "projected_ownership"):
+        if key in rec and rec[key] not in (None, ""):
+            try:
+                val = float(str(rec[key]).replace("%", ""))
+            except Exception:
+                continue
+            if math.isnan(val):
+                continue
+            if val < 0:
+                val = 0.0
+            if val > 1.0:
+                val = val / 100.0
+            return max(min(val, 1.0), 0.0)
+    return None
+
+
+def _team(rec: Dict) -> Optional[str]:
+    for key in ("TeamAbbrev", "Team", "team", "TeamAbbreviation"):
+        val = rec.get(key)
+        if val:
+            return str(val).upper().strip()
+    return None
+
+
+def _ensure_output_dir() -> None:
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+
+def _determine_lineup_target(config: Dict, diversity_cfg: Dict) -> int:
+    raw = diversity_cfg.get("lineup_count") or config.get("num_lineups")
+    try:
+        val = int(raw)
+    except Exception:
+        val = DiversityRules().lineup_count
+    return max(val, 1)
+
+
+def _build_rules(div_cfg: Dict, lineup_target: int) -> DiversityRules:
+    rules = DiversityRules(lineup_count=lineup_target)
+    if "max_shared_players" in div_cfg and div_cfg["max_shared_players"] is not None:
+        try:
+            rules.max_shared_players = int(div_cfg["max_shared_players"])
+        except Exception:
+            pass
+    if "min_jaccard_distance" in div_cfg and div_cfg["min_jaccard_distance"] is not None:
+        try:
+            rules.min_jaccard_distance = float(div_cfg["min_jaccard_distance"])
+        except Exception:
+            pass
+    if "per_player_cap" in div_cfg:
+        rules.per_player_cap = (
+            float(div_cfg["per_player_cap"]) if div_cfg["per_player_cap"] is not None else None
+        )
+    if "per_team_cap" in div_cfg:
+        rules.per_team_cap = (
+            float(div_cfg["per_team_cap"]) if div_cfg["per_team_cap"] is not None else None
+        )
+    if "min_stack_mix" in div_cfg and div_cfg["min_stack_mix"]:
+        rules.min_stack_mix = {str(k): float(v) for k, v in div_cfg["min_stack_mix"].items()}
+    if "max_stack_mix" in div_cfg and div_cfg["max_stack_mix"]:
+        rules.max_stack_mix = {str(k): float(v) for k, v in div_cfg["max_stack_mix"].items()}
+    return rules
+
+
+def _write_candidate_csv(optimizer: _Optimizer, site: str) -> List[List[str]]:
+    lineup_keys: List[List[str]] = []
+    candidate_path = os.path.join(OUTPUT_DIR, "optimized_lineups.csv")
+    with open(candidate_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Lineup"] + [str(i) for i in range(1, 10)])
+        for idx, (players, _) in enumerate(optimizer.lineups):
+            try:
+                ordered = optimizer.sort_lineup(list(players))
+            except Exception:
+                ordered = list(players)
+            display = []
+            for key in ordered:
+                rec = optimizer.player_dict.get(key, {})
+                display.append(_format_player(rec, site))
+            lineup_keys.append(ordered)
+            writer.writerow([idx + 1] + display)
+    return lineup_keys
+
+
+def _build_candidates(
+    optimizer: _Optimizer,
+    lineup_keys: List[List[str]],
+) -> List[Candidate]:
+    candidate_path = os.path.join(OUTPUT_DIR, "optimized_lineups.csv")
+    candidates: List[Candidate] = []
+    with open(candidate_path, "r", newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        headers = next(reader, None)
+        for idx, row in enumerate(reader):
+            players = [cell.strip() for cell in row[1:10] if cell.strip()]
+            keys = lineup_keys[idx] if idx < len(lineup_keys) else []
+            owners: List[Optional[float]] = []
+            teams: List[Optional[str]] = []
+            if keys:
+                for key in keys:
+                    rec = optimizer.player_dict.get(key, {})
+                    owners.append(_ownership(rec))
+                    teams.append(_team(rec))
+            if len(owners) < len(players):
+                owners.extend([None] * (len(players) - len(owners)))
+            if len(teams) < len(players):
+                teams.extend([None] * (len(players) - len(teams)))
+            stack_label = None
+            if analyze_lineup and keys:
+                try:
+                    metrics = analyze_lineup(keys, optimizer.player_dict)
+                except TypeError:
+                    metrics = analyze_lineup(keys)  # type: ignore[call-arg]
+                except Exception:
+                    metrics = None
+                if isinstance(metrics, dict):
+                    stack_label = metrics.get("bucket") or metrics.get("label")
+            candidates.append(
+                Candidate(
+                    players=players,
+                    owners=owners,
+                    teams=teams,
+                    stack_label=stack_label,
+                )
+            )
+    return candidates
+
+
+def _write_diversified_csv(lineups: Iterable[List[str]], filename: str) -> str:
+    path = os.path.join(OUTPUT_DIR, filename)
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["Lineup"] + [str(i) for i in range(1, 10)])
+        for idx, lineup in enumerate(lineups, start=1):
+            writer.writerow([idx] + list(lineup))
+    return path
+
+
+def main() -> None:
+    _ensure_output_dir()
+    config = _load_config()
+    diversity_cfg = config.get("diversity", {}) or {}
+
+    site = str(config.get("site", "dk"))
+    num_uniques = int(config.get("num_uniques", 1))
+    lineup_target = _determine_lineup_target(config, diversity_cfg)
+    pool_factor = float(diversity_cfg.get("pool_factor", 4.0))
+
+    optimizer = _Optimizer(
+        site=site,
+        num_lineups=lineup_target,
+        num_uniques=num_uniques,
+        profile=config.get("profile"),
+        pool_factor=max(pool_factor, 1.0),
+    )
+
+    desired_final = optimizer.num_lineups or lineup_target
+    if desired_final <= 0:
+        desired_final = lineup_target
+    pool_size = max(int(math.ceil(desired_final * pool_factor)), desired_final)
+    optimizer.num_lineups = pool_size
+    if desired_final:
+        ratio = pool_size / max(desired_final, 1)
+        adjust = pool_factor / max(ratio, 1.0)
+        optimizer.pool_factor = max(adjust, 1.0)
+
+    optimizer.optimize()
+
+    lineup_keys = _write_candidate_csv(optimizer, site)
+    candidates = _build_candidates(optimizer, lineup_keys)
+
+    rules = _build_rules(diversity_cfg, desired_final)
+    portfolio = diversify_portfolio(candidates, rules)
+
+    diversified_path = _write_diversified_csv(portfolio.lineups, "optimized_lineups_diverse.csv")
+
+    audit = {
+        "rules": asdict(rules),
+        "metrics": portfolio.metrics,
+        "selected_count": len(portfolio.lineups),
+        "initial_candidate_count": len(candidates),
+        "taken_indices": portfolio.taken_idx,
+        "reasons_rejected": portfolio.reasons_rejected,
+        "candidate_pool_path": os.path.join("output", "optimized_lineups.csv"),
+        "diversified_path": os.path.relpath(diversified_path, ROOT_DIR),
+        "pool_size": pool_size,
+        "requested_lineups": desired_final,
+        "pool_factor": pool_factor,
+    }
+    audit_path = os.path.join(OUTPUT_DIR, "diversity_audit.json")
+    with open(audit_path, "w", encoding="utf-8") as fh:
+        json.dump(audit, fh, indent=2)
+
+    print(f"Wrote diversified lineups to {diversified_path}")
+    print(f"Audit saved to {audit_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_simulator_with_diversity.py
+++ b/scripts/run_simulator_with_diversity.py
@@ -1,0 +1,186 @@
+"""Run the classic GPP simulator after applying portfolio diversity guards."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from dataclasses import asdict
+from typing import Dict, Iterable, List, Optional
+
+from src.anti_cannibalizer import Candidate, DiversityRules, diversify_portfolio
+
+try:  # Simulator class name differs between historical versions
+    from src.nfl_gpp_simulator import GppSimulator as _Simulator  # type: ignore
+except ImportError:  # pragma: no cover
+    from src.nfl_gpp_simulator import NFL_GPP_Simulator as _Simulator  # type: ignore
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+OUTPUT_DIR = os.path.join(ROOT_DIR, "output")
+UPLOAD_DIR = os.path.join(ROOT_DIR, "uploads")
+CONFIG_PATHS = [
+    os.path.join(ROOT_DIR, "config.json"),
+    os.path.join(ROOT_DIR, "sample.config.json"),
+]
+
+PRIORITY_CSVS = [
+    "optimized_lineups_diverse.csv",
+    "optimized_lineups.csv",
+    "saved_lineups.csv",
+]
+
+
+def _load_config() -> Dict:
+    for path in CONFIG_PATHS:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+    return {}
+
+
+def _as_bool(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y"}:
+        return True
+    if text in {"0", "false", "no", "n"}:
+        return False
+    return default
+
+
+def _build_rules(div_cfg: Dict, lineup_target: int) -> DiversityRules:
+    rules = DiversityRules(lineup_count=lineup_target)
+    if "max_shared_players" in div_cfg and div_cfg["max_shared_players"] is not None:
+        try:
+            rules.max_shared_players = int(div_cfg["max_shared_players"])
+        except Exception:
+            pass
+    if "min_jaccard_distance" in div_cfg and div_cfg["min_jaccard_distance"] is not None:
+        try:
+            rules.min_jaccard_distance = float(div_cfg["min_jaccard_distance"])
+        except Exception:
+            pass
+    if "per_player_cap" in div_cfg:
+        rules.per_player_cap = (
+            float(div_cfg["per_player_cap"]) if div_cfg["per_player_cap"] is not None else None
+        )
+    if "per_team_cap" in div_cfg:
+        rules.per_team_cap = (
+            float(div_cfg["per_team_cap"]) if div_cfg["per_team_cap"] is not None else None
+        )
+    if "min_stack_mix" in div_cfg and div_cfg["min_stack_mix"]:
+        rules.min_stack_mix = {str(k): float(v) for k, v in div_cfg["min_stack_mix"].items()}
+    if "max_stack_mix" in div_cfg and div_cfg["max_stack_mix"]:
+        rules.max_stack_mix = {str(k): float(v) for k, v in div_cfg["max_stack_mix"].items()}
+    return rules
+
+
+def _find_source_csv() -> Optional[str]:
+    for name in PRIORITY_CSVS:
+        path = os.path.join(OUTPUT_DIR, name)
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def _load_lineups(path: str) -> List[List[str]]:
+    lineups: List[List[str]] = []
+    with open(path, "r", newline="", encoding="utf-8") as fh:
+        reader = csv.reader(fh)
+        header = next(reader, None)
+        for row in reader:
+            players = [cell.strip() for cell in row[1:10] if cell.strip()]
+            if players:
+                lineups.append(players)
+    return lineups
+
+
+def _write_csv(lineups: Iterable[List[str]], path: str, include_index: bool = True) -> None:
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        if include_index:
+            writer.writerow(["Lineup"] + [str(i) for i in range(1, 10)])
+            for idx, lineup in enumerate(lineups, start=1):
+                writer.writerow([idx] + list(lineup))
+        else:
+            writer.writerow(["QB", "RB", "RB", "WR", "WR", "WR", "TE", "FLEX", "DST"])
+            for lineup in lineups:
+                writer.writerow(list(lineup))
+
+
+def main() -> None:
+    config = _load_config()
+    diversity_cfg = config.get("diversity", {}) or {}
+
+    source_csv = _find_source_csv()
+    if not source_csv:
+        raise FileNotFoundError("No lineup CSV found in output/. Run the optimizer first.")
+
+    raw_lineups = _load_lineups(source_csv)
+    if not raw_lineups:
+        raise ValueError(f"No lineups parsed from {source_csv}")
+
+    requested = int(config.get("num_sim_lineups", len(raw_lineups)))
+    requested = max(1, min(requested, len(raw_lineups)))
+
+    rules = _build_rules(diversity_cfg, requested)
+    candidates = [Candidate(players=lu) for lu in raw_lineups]
+    portfolio = diversify_portfolio(candidates, rules)
+
+    diversified_lineups = portfolio.lineups
+    diversified_path = os.path.join(OUTPUT_DIR, "simulator_diverse_lineups.csv")
+    _write_csv(diversified_lineups, diversified_path, include_index=True)
+
+    site = str(config.get("site", "dk"))
+    uploads_site_dir = os.path.join(UPLOAD_DIR, site)
+    os.makedirs(uploads_site_dir, exist_ok=True)
+    tournament_path = os.path.join(uploads_site_dir, "tournament_lineups.csv")
+    _write_csv(diversified_lineups, tournament_path, include_index=False)
+
+    field_size = int(config.get("field_size", max(len(diversified_lineups), 1)))
+    num_iterations = int(config.get("num_iterations", 1000))
+    use_contest_data = _as_bool(config.get("use_contest_data"), False)
+    use_lineup_input = _as_bool(config.get("use_lineup_input"), True)
+    profile = config.get("profile")
+    pool_factor = float(config.get("pool_factor", 5.0))
+
+    simulator = _Simulator(
+        site,
+        field_size,
+        num_iterations,
+        use_contest_data,
+        use_lineup_input,
+        profile=profile,
+        pool_factor=pool_factor,
+    )
+    simulator.generate_field_lineups()
+    simulator.run_tournament_simulation()
+    sim_outputs = simulator.output()
+
+    audit = {
+        "rules": asdict(rules),
+        "metrics": portfolio.metrics,
+        "selected_count": len(diversified_lineups),
+        "initial_candidate_count": len(raw_lineups),
+        "taken_indices": portfolio.taken_idx,
+        "reasons_rejected": portfolio.reasons_rejected,
+        "source_csv": os.path.relpath(source_csv, ROOT_DIR),
+        "diversified_path": os.path.relpath(diversified_path, ROOT_DIR),
+        "tournament_path": os.path.relpath(tournament_path, ROOT_DIR),
+        "simulator_outputs": sim_outputs,
+    }
+    audit_path = os.path.join(OUTPUT_DIR, "simulator_diversity_audit.json")
+    with open(audit_path, "w", encoding="utf-8") as fh:
+        json.dump(audit, fh, indent=2)
+
+    print(f"Diversified simulator lineups saved to {diversified_path}")
+    print(f"Tournament input written to {tournament_path}")
+    print(f"Simulator outputs: {sim_outputs}")
+    print(f"Audit saved to {audit_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/anti_cannibalizer.py
+++ b/src/anti_cannibalizer.py
@@ -1,0 +1,312 @@
+"""Portfolio diversity guards for NFL DFS lineups.
+
+This module adds a light-weight selection layer that can be used on top of
+existing optimisation/simulation flows.  Given an oversized pool of candidate
+lineups, we greedily construct a diversified portfolio subject to overlap,
+exposure and stack mix rules.
+"""
+from __future__ import annotations
+
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Dict, List, Optional, Sequence
+
+try:  # ``stack_metrics`` lives in the repo; guard for standalone usage/tests.
+    from . import stack_metrics  # type: ignore
+except Exception:  # pragma: no cover - fallback when used outside the package
+    stack_metrics = None  # type: ignore
+
+
+@dataclass
+class DiversityRules:
+    """Configuration for pruning a candidate lineup pool."""
+
+    max_shared_players: int = 6
+    min_jaccard_distance: float = 0.20
+    per_player_cap: Optional[float] = 0.45
+    per_team_cap: Optional[float] = 0.40
+    min_stack_mix: Optional[Dict[str, float]] = None
+    max_stack_mix: Optional[Dict[str, float]] = None
+    lineup_count: int = 20
+
+
+@dataclass
+class Candidate:
+    """Lineup candidate produced by the optimiser or an upstream process."""
+
+    players: List[str]
+    owners: Optional[List[Optional[float]]] = None
+    teams: Optional[List[Optional[str]]] = None
+    stack_label: Optional[str] = None
+    score: float = 0.0
+
+
+@dataclass
+class PortfolioResult:
+    """Result of the greedy diversification pass."""
+
+    lineups: List[List[str]]
+    taken_idx: List[int]
+    metrics: Dict[str, float]
+    reasons_rejected: Dict[str, int]
+
+
+def jaccard(a: Sequence[str], b: Sequence[str]) -> float:
+    """Return the Jaccard similarity of two lineups."""
+
+    set_a = set(a)
+    set_b = set(b)
+    union = set_a | set_b
+    if not union:
+        return 0.0
+    return len(set_a & set_b) / len(union)
+
+
+def hamming_shared(a: Sequence[str], b: Sequence[str]) -> int:
+    """Count of shared players between two unordered lineups."""
+
+    return len(set(a) & set(b))
+
+
+def lineup_score_ownership_product(owners: Optional[Sequence[Optional[float]]]) -> float:
+    """Return a scarcity score using the product of ownerships.
+
+    Ownership values are expected on the 0..1 scale.  Values outside this range
+    are coerced by dividing by 100 if they look like percentages and by clamping
+    into the [1e-6, 1] interval before taking the product.
+    """
+
+    if not owners:
+        return 0.0
+
+    product = 1.0
+    has_value = False
+    for raw in owners:
+        if raw is None:
+            continue
+        try:
+            val = float(raw)
+        except Exception:
+            continue
+        if math.isnan(val):
+            continue
+        if val < 0:
+            val = 0.0
+        if val > 1.0:
+            val = val / 100.0
+        val = max(min(val, 1.0), 1e-6)
+        product *= val
+        has_value = True
+    if not has_value:
+        return 0.0
+    return -math.log(product)
+
+
+def _infer_stack_label(players: Sequence[str], supplied: Optional[str]) -> str:
+    """Return a stack label using ``stack_metrics`` when available."""
+
+    if supplied:
+        return supplied
+    if stack_metrics is None:
+        return "No Stack"
+    try:
+        metrics = stack_metrics.analyze_lineup(players)  # type: ignore[arg-type]
+    except TypeError:
+        # Older signature expects the player dictionary as the second argument;
+        # fall back to an empty dict which yields the "No Stack" bucket.
+        try:
+            metrics = stack_metrics.analyze_lineup(players, {})  # type: ignore[arg-type]
+        except Exception:
+            return "No Stack"
+    except Exception:
+        return "No Stack"
+    label = None
+    if isinstance(metrics, dict):
+        label = metrics.get("label") or metrics.get("bucket")
+    return label or "No Stack"
+
+
+def _cap_count(cap: Optional[float], total: int) -> Optional[int]:
+    if cap is None:
+        return None
+    try:
+        limit = int(math.floor(float(cap) * total))
+    except Exception:
+        return None
+    return max(limit, 0)
+
+
+def _pairwise_jaccard_mean(lineup_sets: List[set]) -> float:
+    if len(lineup_sets) < 2:
+        return 0.0
+    total = 0.0
+    count = 0
+    for a, b in combinations(lineup_sets, 2):
+        union = a | b
+        if not union:
+            continue
+        total += len(a & b) / len(union)
+        count += 1
+    return total / count if count else 0.0
+
+
+def diversify_portfolio(candidates: List[Candidate], rules: DiversityRules) -> PortfolioResult:
+    """Greedily select a diversified subset of the candidate lineups."""
+
+    if rules.lineup_count < 0:
+        rules.lineup_count = 0
+
+    processed: List[Dict[str, object]] = []
+    for idx, cand in enumerate(candidates):
+        players = list(cand.players or [])
+        owners = list(cand.owners or [])
+        teams = list(cand.teams or [])
+        label = _infer_stack_label(players, cand.stack_label)
+        score = cand.score
+        if score == 0:
+            score = lineup_score_ownership_product(owners)
+        team_set = {str(t).upper() for t in teams if t}
+        processed.append(
+            {
+                "index": idx,
+                "players": players,
+                "owners": owners,
+                "teams": teams,
+                "team_set": team_set,
+                "label": label or "No Stack",
+                "score": float(score),
+            }
+        )
+
+    processed.sort(key=lambda item: (-item["score"], item["index"]))  # type: ignore[index]
+
+    max_shared = rules.max_shared_players if rules.max_shared_players is not None else None
+    jaccard_threshold = None
+    if rules.min_jaccard_distance is not None:
+        try:
+            jaccard_threshold = 1.0 - float(rules.min_jaccard_distance)
+        except Exception:
+            jaccard_threshold = None
+    player_cap_limit = _cap_count(rules.per_player_cap, rules.lineup_count)
+    team_cap_limit = _cap_count(rules.per_team_cap, rules.lineup_count)
+
+    selected_lineups: List[List[str]] = []
+    selected_sets: List[set] = []
+    taken_indices: List[int] = []
+    taken_set = set()
+    player_counts: Counter = Counter()
+    team_counts: Counter = Counter()
+    stack_counts: Counter = Counter()
+    reasons = defaultdict(int)
+
+    def _attempt_take(entry: Dict[str, object]) -> bool:
+        if len(selected_lineups) >= rules.lineup_count > 0:
+            return False
+        players = entry["players"]  # type: ignore[assignment]
+        label = entry["label"]  # type: ignore[assignment]
+        team_set = entry["team_set"]  # type: ignore[assignment]
+        idx = entry["index"]  # type: ignore[assignment]
+
+        unique_players = set(players)
+        if player_cap_limit is not None and player_cap_limit >= 0:
+            for player in unique_players:
+                if player_counts[player] >= player_cap_limit:
+                    key = f"player_cap:{player}"
+                    reasons[key] += 1
+                    return False
+        if team_cap_limit is not None and team_cap_limit >= 0 and team_set:
+            for team in team_set:
+                if team_counts[team] >= team_cap_limit:
+                    key = f"team_cap:{team}"
+                    reasons[key] += 1
+                    return False
+
+        if rules.max_stack_mix and label in rules.max_stack_mix:
+            try:
+                allowed = math.floor(float(rules.max_stack_mix[label]) * rules.lineup_count)
+            except Exception:
+                allowed = None
+            if allowed is not None and allowed >= 0 and stack_counts[label] >= allowed:
+                key = f"stack_max:{label}"
+                reasons[key] += 1
+                return False
+
+        if max_shared is not None or jaccard_threshold is not None:
+            for existing in selected_sets:
+                if max_shared is not None and max_shared >= 0:
+                    shared = len(existing & unique_players)
+                    if shared > max_shared:
+                        key = f"overlap:{shared}"
+                        reasons[key] += 1
+                        return False
+                if jaccard_threshold is not None:
+                    union = existing | unique_players
+                    if not union:
+                        continue
+                    jac = len(existing & unique_players) / len(union)
+                    if jac > jaccard_threshold:
+                        key = f"jaccard:{jac:.2f}"
+                        reasons[key] += 1
+                        return False
+
+        selected_lineups.append(list(players))
+        selected_sets.append(unique_players)
+        taken_indices.append(int(idx))
+        taken_set.add(int(idx))
+        for player in unique_players:
+            player_counts[player] += 1
+        for team in team_set:
+            team_counts[team] += 1
+        stack_counts[label] += 1
+        return True
+
+    for entry in processed:
+        if len(selected_lineups) >= rules.lineup_count > 0:
+            break
+        _attempt_take(entry)
+
+    if rules.min_stack_mix:
+        for label, frac in rules.min_stack_mix.items():
+            try:
+                required = int(math.ceil(float(frac) * rules.lineup_count))
+            except Exception:
+                required = 0
+            required = max(0, min(required, rules.lineup_count))
+            guard = 0
+            while stack_counts.get(label, 0) < required and len(selected_lineups) < rules.lineup_count:
+                added = False
+                for entry in processed:
+                    if entry["label"] != label:  # type: ignore[index]
+                        continue
+                    if entry["index"] in taken_set:  # type: ignore[operator]
+                        continue
+                    if _attempt_take(entry):
+                        added = True
+                        break
+                if not added:
+                    break
+                guard += 1
+                if guard > len(processed):
+                    break
+            if stack_counts.get(label, 0) < required:
+                deficit = required - stack_counts.get(label, 0)
+                if deficit > 0:
+                    reasons[f"stack_min_unmet:{label}"] += deficit
+
+    metrics: Dict[str, float] = {
+        "pairwise_jaccard_mean": _pairwise_jaccard_mean(selected_sets),
+        "player_HHI": sum((count / len(selected_lineups)) ** 2 for count in player_counts.values())
+        if selected_lineups
+        else 0.0,
+        "selected_lineups": float(len(selected_lineups)),
+        "requested_lineups": float(rules.lineup_count),
+    }
+
+    return PortfolioResult(
+        lineups=selected_lineups,
+        taken_idx=taken_indices,
+        metrics=metrics,
+        reasons_rejected=dict(reasons),
+    )


### PR DESCRIPTION
## Summary
- implement an `anti_cannibalizer` helper with overlap, distance, exposure and stack-mix enforcement for lineup portfolios
- add `run_optimizer_diverse.py` to build an oversized candidate pool, filter it with the diversity guard, and emit CSV/JSON audits
- add `run_simulator_with_diversity.py` to reapply the guards before running the existing GPP simulator and to save diversified inputs
- document the workflow in the README with usage instructions and an example config block

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d41d143b388330acdda526cd5f09ef